### PR TITLE
Refactor shutdown handling

### DIFF
--- a/app/Main.java
+++ b/app/Main.java
@@ -1,0 +1,29 @@
+package app;
+
+import javax.swing.SwingUtilities;
+
+import controller.SceneManager;
+
+/**
+ * Application entry point and centralized shutdown handler.
+ */
+public final class Main {
+
+    private static SceneManager sceneManager;
+
+    private Main() {
+        // no instances
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> sceneManager = new SceneManager());
+    }
+
+    /**
+     * Shuts down the application gracefully.
+     */
+    public static void shutdown() {
+        // Any future cleanup logic can be placed here
+        System.exit(0);
+    }
+}

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -6,6 +6,7 @@ import model.util.InputValidator;
 import persistence.GameData;
 import persistence.SaveLoadService;
 import view.*;
+import app.Main;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -98,7 +99,7 @@ public void actionPerformed(ActionEvent e) {
         case MainMenuView.ACTION_EXIT -> {
             handleSaveGameRequest();
             mainMenuView.dispose(); // Close the MainMenuView
-            System.exit(0); // Close the application
+            Main.shutdown(); // Centralized application shutdown
         }
         default -> {
             JOptionPane.showMessageDialog(mainMenuView, "Unknown action: " + command, "Unknown Action", JOptionPane.WARNING_MESSAGE);

--- a/view/MainMenuView.java
+++ b/view/MainMenuView.java
@@ -5,6 +5,7 @@ import java.awt.event.*;
 import javax.swing.*;
 
 import controller.GameManagerController;
+import app.Main;
 
 /**
  * The main menu view for Fatal Fantasy: Tactics Game.
@@ -53,8 +54,8 @@ public class MainMenuView extends JFrame {
                 );
 
                 if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); 
-                    System.exit(0);
+                    dispose();
+                    Main.shutdown();
                 }
             }
         });


### PR DESCRIPTION
## Summary
- add `app.Main` as application entry point
- remove direct `System.exit` usage from `GameManagerController`
- remove direct `System.exit` usage from `MainMenuView`

## Testing
- `javac $(find . -name '*.java')` *(fails: cannot find symbol)*

------
https://chatgpt.com/codex/tasks/task_e_6882c783b38083288802a734040b2071