### PR TITLE
Fix adding players with immutable list

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -172,9 +172,11 @@ public void actionPerformed(ActionEvent e) {
         // Load existing game data (or create new if no data exists)
         GameData gameData = SaveLoadService.loadGame();
 
-        // Add the new players to the game data
-        gameData.getAllPlayers().add(player1);
-        gameData.getAllPlayers().add(player2);
+        // Add the new players to the game data using a mutable copy
+        List<Player> existing = new ArrayList<>(gameData.getAllPlayers());
+        existing.add(player1);
+        existing.add(player2);
+        gameData.setAllPlayers(existing);
 
         // Save the updated game data with the new players
         SaveLoadService.saveGame(gameData);  // Save the game data with the newly added players

--- a/persistence/SaveLoadService.java
+++ b/persistence/SaveLoadService.java
@@ -5,6 +5,7 @@ import model.core.HallOfFameEntry;
 import model.util.GameException;
 import java.io.*;
 import java.util.List;
+import java.util.ArrayList;
 
 public class SaveLoadService {
 
@@ -75,8 +76,10 @@ public class SaveLoadService {
             // Load the current game data
             GameData gameData = loadGame(); // This may throw GameException if something goes wrong
 
-            // Add the new player to the game data
-            gameData.getAllPlayers().add(player);
+            // Add the new player to the game data using a mutable copy
+            List<Player> players = new ArrayList<>(gameData.getAllPlayers());
+            players.add(player);
+            gameData.setAllPlayers(players);
 
             // Save the updated game data
             saveGame(gameData); // This may throw GameException if save fails


### PR DESCRIPTION
## Summary
- prevent UnsupportedOperationException when adding players
- update `GameManagerController` to copy and reset player list
- update `SaveLoadService.addPlayer` to use a mutable list

## Testing
- `javac $(find . -name '*.java')` *(fails: cannot find symbol PlayerRegistrationView, RoundedTextField, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6882c7649618832885486e73ec2df89c