### PR TITLE
Add trade system

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,9 @@ src/
 - **Main Menu to Player Registration**: Clicking "Register Players" shows the PlayerRegistrationView. Two players must be registered (unique, not empty). Data is saved, and confirmation is shown. Fields are reset after registration.
 - **Player data persistence**: Uses SaveLoadService and GameData.
 - **Manage Characters**: Enabled after registration.
-- **Hall of Fame**: Loads from file.  
-- **Ongoing**: Integration of inventory, trading, AI, and battle screens.
+- **Hall of Fame**: Loads from file.
+- **Ongoing**: Integration of inventory, AI, and battle screens.
+- **New**: Magic item trading GUI using `TradeView`/`TradeController`.
 
 ---
 
@@ -406,6 +407,7 @@ Status Effects (e.g., stun, poison)
 Leveling system (XP and rewards)
 
 Magic Item Trading GUI
+  - Trade magic items between players via a dedicated screen.
 
 More classes/races
 
@@ -427,6 +429,7 @@ src/
   controller/
     GameManagerController.java
     SceneManager.java
+    TradeController.java
     (etc)
   model/
     core/
@@ -436,6 +439,7 @@ src/
     mainmenu/
     character/
     battle/
+    TradeView.java
     (etc)
   persistence/
     SaveLoadService.java

--- a/controller/TradeController.java
+++ b/controller/TradeController.java
@@ -1,0 +1,109 @@
+package controller;
+
+import model.core.Character;
+import model.core.Player;
+import model.item.MagicItem;
+import model.util.GameException;
+import model.util.InputValidator;
+import model.util.TradeOffer;
+import persistence.GameData;
+import persistence.SaveLoadService;
+import view.TradeView;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Controller handling magic item trading between players.
+ * <p>
+ * Validates selections, performs the exchange, and saves
+ * updated player data via {@link SaveLoadService}.
+ */
+public class TradeController implements ActionListener {
+
+    private final TradeView view;
+    private final List<Player> players;
+
+    public TradeController(TradeView view, List<Player> players) throws GameException {
+        InputValidator.requireNonNull(view, "view");
+        InputValidator.requireNonNull(players, "players");
+        this.view = view;
+        this.players = players;
+        view.setActionListener(this);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String cmd = e.getActionCommand();
+        if (TradeView.TRADE.equals(cmd)) {
+            handleTrade();
+        } else if (TradeView.CANCEL.equals(cmd)) {
+            view.dispose();
+        }
+    }
+
+    private void handleTrade() {
+        try {
+            Character c1 = view.getSelectedChar1();
+            Character c2 = view.getSelectedChar2();
+            InputValidator.requireNonNull(c1, "Offering character");
+            InputValidator.requireNonNull(c2, "Receiving character");
+
+            List<MagicItem> offered = new ArrayList<>(view.getSelectedItems1());
+            List<MagicItem> requested = new ArrayList<>(view.getSelectedItems2());
+
+            // Validate ownership
+            if (!c1.getInventory().getAllItems().containsAll(offered) ||
+                !c2.getInventory().getAllItems().containsAll(requested)) {
+                view.showError("Invalid item selection for trade.");
+                return;
+            }
+
+            Player p1 = findPlayerForCharacter(c1);
+            Player p2 = findPlayerForCharacter(c2);
+
+            // Construct offer for record/possible future use
+            new TradeOffer(p1, p2, offered, requested);
+
+            // Execute trade
+            for (MagicItem m : offered) {
+                c1.getInventory().removeItem(m);
+                c2.getInventory().addItem(m);
+            }
+            for (MagicItem m : requested) {
+                c2.getInventory().removeItem(m);
+                c1.getInventory().addItem(m);
+            }
+
+            persist();
+            view.showInfo("Trade completed successfully.");
+            view.refreshLists();
+        } catch (GameException ex) {
+            view.showError(ex.getMessage());
+        }
+    }
+
+    private Player findPlayerForCharacter(Character c) throws GameException {
+        for (Player p : players) {
+            if (p.getCharacters().contains(c)) {
+                return p;
+            }
+        }
+        throw new GameException("Character does not belong to any loaded player.");
+    }
+
+    private void persist() {
+        try {
+            GameData data = SaveLoadService.loadGame();
+            data.setAllPlayers(players);
+            SaveLoadService.saveGame(data);
+        } catch (GameException e) {
+            JOptionPane.showMessageDialog(view, "Failed to save game: " + e.getMessage(),
+                    "Save Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}
+

--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -1,0 +1,159 @@
+package view;
+
+import model.core.Character;
+import model.core.Player;
+import model.item.MagicItem;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.util.List;
+
+/**
+ * Simple GUI for trading magic items between two players.
+ * <p>
+ * Purely responsible for presenting item lists and collecting
+ * user selections. All validation and persistence are handled
+ * in the controller layer.
+ */
+public class TradeView extends JFrame {
+
+    public static final String TRADE = "TRADE";
+    public static final String CANCEL = "CANCEL";
+
+    private final Player player1;
+    private final Player player2;
+
+    private final JComboBox<Character> charBox1;
+    private final JComboBox<Character> charBox2;
+
+    private final DefaultListModel<MagicItem> model1;
+    private final DefaultListModel<MagicItem> model2;
+    private final JList<MagicItem> list1;
+    private final JList<MagicItem> list2;
+
+    private final JButton btnTrade;
+    private final JButton btnCancel;
+
+    public TradeView(Player p1, Player p2) {
+        super("Trade Items");
+        this.player1 = p1;
+        this.player2 = p2;
+
+        charBox1 = new JComboBox<>(p1.getCharacters().toArray(new Character[0]));
+        charBox2 = new JComboBox<>(p2.getCharacters().toArray(new Character[0]));
+
+        model1 = new DefaultListModel<>();
+        model2 = new DefaultListModel<>();
+        list1 = new JList<>(model1);
+        list2 = new JList<>(model2);
+        list1.setVisibleRowCount(8);
+        list2.setVisibleRowCount(8);
+        list1.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        list2.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+
+        btnTrade = new RoundedButton("Trade");
+        btnCancel = new RoundedButton("Cancel");
+
+        initUI();
+        configureWindow();
+        bindComboListeners();
+        refreshLists();
+    }
+
+    private void configureWindow() {
+        setSize(600, 400);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    }
+
+    private void initUI() {
+        JPanel main = new JPanel(new BorderLayout());
+
+        JPanel lists = new JPanel(new GridLayout(1, 2, 10, 10));
+        lists.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        JPanel left = new JPanel(new BorderLayout());
+        left.add(charBox1, BorderLayout.NORTH);
+        left.add(new JScrollPane(list1), BorderLayout.CENTER);
+        lists.add(left);
+
+        JPanel right = new JPanel(new BorderLayout());
+        right.add(charBox2, BorderLayout.NORTH);
+        right.add(new JScrollPane(list2), BorderLayout.CENTER);
+        lists.add(right);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.CENTER, 20, 10));
+        buttons.add(btnTrade);
+        buttons.add(btnCancel);
+
+        main.add(lists, BorderLayout.CENTER);
+        main.add(buttons, BorderLayout.SOUTH);
+
+        setContentPane(main);
+    }
+
+    private void bindComboListeners() {
+        charBox1.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                refreshLists();
+            }
+        });
+        charBox2.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                refreshLists();
+            }
+        });
+    }
+
+    public void refreshLists() {
+        model1.clear();
+        Character c1 = getSelectedChar1();
+        if (c1 != null) {
+            for (MagicItem m : c1.getInventory().getAllItems()) {
+                model1.addElement(m);
+            }
+        }
+
+        model2.clear();
+        Character c2 = getSelectedChar2();
+        if (c2 != null) {
+            for (MagicItem m : c2.getInventory().getAllItems()) {
+                model2.addElement(m);
+            }
+        }
+    }
+
+    public Character getSelectedChar1() {
+        return (Character) charBox1.getSelectedItem();
+    }
+
+    public Character getSelectedChar2() {
+        return (Character) charBox2.getSelectedItem();
+    }
+
+    public List<MagicItem> getSelectedItems1() {
+        return list1.getSelectedValuesList();
+    }
+
+    public List<MagicItem> getSelectedItems2() {
+        return list2.getSelectedValuesList();
+    }
+
+    public void setActionListener(ActionListener l) {
+        btnTrade.setActionCommand(TRADE);
+        btnCancel.setActionCommand(CANCEL);
+        btnTrade.addActionListener(l);
+        btnCancel.addActionListener(l);
+    }
+
+    public void showInfo(String msg) {
+        JOptionPane.showMessageDialog(this, msg, "Info", JOptionPane.INFORMATION_MESSAGE);
+    }
+
+    public void showError(String msg) {
+        JOptionPane.showMessageDialog(this, msg, "Error", JOptionPane.ERROR_MESSAGE);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `TradeView` UI for selecting characters and items to trade
- add `TradeController` using `model.util.TradeOffer` to validate and process trades
- document trading feature in README

## Testing
- `javac $(find . -name '*.java')` *(fails: displayBattleStart undefined, SingleUseItem super call position)*

------
https://chatgpt.com/codex/tasks/task_e_6882cd7005588328b0dcbf4d4b645d8e