### PR TITLE
Refactor shutdown handling

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -11,6 +11,8 @@ import app.Main;
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -66,6 +68,19 @@ public final class GameManagerController implements ActionListener {
     /** Wires this controller to the main menu buttons. */
     private void bindUI() {
         mainMenuView.setController(this);
+        mainMenuView.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                int choice = JOptionPane.showConfirmDialog(
+                        mainMenuView,
+                        "Are you sure you want to quit?",
+                        "Confirm Exit",
+                        JOptionPane.YES_NO_OPTION);
+                if (choice == JOptionPane.YES_OPTION) {
+                    quitApplication();
+                }
+            }
+        });
     }
 
     /** Main button dispatcher for MainMenuView. */
@@ -97,9 +112,7 @@ public void actionPerformed(ActionEvent e) {
             // Ideally, you should call sceneManager.showBattleView() here when ready
         }
         case MainMenuView.ACTION_EXIT -> {
-            handleSaveGameRequest();
-            mainMenuView.dispose(); // Close the MainMenuView
-            Main.shutdown(); // Centralized application shutdown
+            quitApplication();
         }
         default -> {
             JOptionPane.showMessageDialog(mainMenuView, "Unknown action: " + command, "Unknown Action", JOptionPane.WARNING_MESSAGE);
@@ -195,6 +208,15 @@ public void actionPerformed(ActionEvent e) {
 
     public void navigateBackToMainMenu() {
         SwingUtilities.invokeLater(() -> mainMenuView.setVisible(true));
+    }
+
+    /**
+     * Handles all logic required when the application is requested to exit.
+     */
+    private void quitApplication() {
+        handleSaveGameRequest();
+        mainMenuView.dispose();
+        Main.shutdown();
     }
 
     // === Game Data Save/Load Methods ===

--- a/view/MainMenuView.java
+++ b/view/MainMenuView.java
@@ -5,7 +5,6 @@ import java.awt.event.*;
 import javax.swing.*;
 
 import controller.GameManagerController;
-import app.Main;
 
 /**
  * The main menu view for Fatal Fantasy: Tactics Game.
@@ -42,23 +41,6 @@ public class MainMenuView extends JFrame {
 
         setSize(800, 700);
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
-
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    MainMenuView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
-
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose();
-                    Main.shutdown();
-                }
-            }
-        });
 
         setLocationRelativeTo(null);
         setResizable(false);


### PR DESCRIPTION
## Summary
- keep `MainMenuView` purely focused on rendering
- handle quit confirmation inside `GameManagerController`
- add controller helper to perform shutdown

## Testing
- `javac controller/GameManagerController.java view/MainMenuView.java`
- `javac $(find . -name '*.java')` *(fails: SingleUseItem.java, BattleController.java)*

------
https://chatgpt.com/codex/tasks/task_e_6882cd727edc8328a29845848405c849