### PR TITLE
Implement single-use item effects

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -102,15 +102,8 @@ public final class BattleController {
         if (!user.getInventory().getAllItems().contains(item)) {
             throw new GameException("Item is not in user's inventory.");
         }
-        // Apply item effect. You must implement this effect method according to your game logic.
-        // Example: item.applyEffect(user, battle, battle.getCombatLog());
-        // (You'll need to pass the appropriate target if applicable)
-
-        // -- PLACEHOLDER: Apply effect logic here (should be part of SingleUseItem, or use effect strategy) --
-        // Example (pseudo):
-        // item.applyEffect(user, target, battle, battle.getCombatLog());
-        // For now, just record the usage:
-        battle.getCombatLog().addEntry(user.getName() + " used item: " + item.getName());
+        // Apply the item's effect and log the outcome
+        item.applyEffect(user, battle.getCombatLog());
 
         // Remove the item from inventory after use
         user.getInventory().removeItem(item);

--- a/model/item/SingleUseEffectType.java
+++ b/model/item/SingleUseEffectType.java
@@ -1,0 +1,13 @@
+package model.item;
+
+/**
+ * Enumerates supported effects for {@link SingleUseItem}s.
+ */
+public enum SingleUseEffectType {
+    /** Restores HP to the user. */
+    HEAL_HP,
+    /** Restores EP to the user. */
+    RESTORE_EP,
+    /** Revives the user from KO with a percentage of max HP. */
+    REVIVE
+}

--- a/model/service/MagicItemFactory.java
+++ b/model/service/MagicItemFactory.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
-import model.item.ItemType;
 import model.item.MagicItem;
 import model.item.PassiveItem;
 import model.item.SingleUseItem;
+import model.item.SingleUseEffectType;
 
 /**
  * <h2>MagicItemFactory</h2>
@@ -30,17 +30,20 @@ public final class MagicItemFactory {
      * ----------------------------------------------------------- */
 
     private static final List<MagicItem> COMMON_ITEMS = List.of(
-        new SingleUseItem("Minor Healing Potion", "Restore 25 HP.", "Common"),
+        new SingleUseItem("Minor Healing Potion", "Restore 25 HP.", "Common",
+                SingleUseEffectType.HEAL_HP, 25),
         new PassiveItem("Copper Ring", "Max EP +5.", "Common")
     );
 
     private static final List<MagicItem> UNCOMMON_ITEMS = List.of(
-        new SingleUseItem("Elixir of Focus", "Restore 15 EP.", "Uncommon"),
+        new SingleUseItem("Elixir of Focus", "Restore 15 EP.", "Uncommon",
+                SingleUseEffectType.RESTORE_EP, 15),
         new PassiveItem("Silver Amulet", "Max HP +15.", "Uncommon")
     );
 
     private static final List<MagicItem> RARE_ITEMS = List.of(
-        new SingleUseItem("Phoenix Tear", "Revive from KO with 50% HP.", "Rare"),
+        new SingleUseItem("Phoenix Tear", "Revive from KO with 50% HP.", "Rare",
+                SingleUseEffectType.REVIVE, 50),
         new PassiveItem("Golden Dragon Scale", "Defense +10%.", "Rare")
     );
 

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -210,4 +210,26 @@ public class BattleView extends JPanel {
     public void addUseAbilityP2Listener(ActionListener listener) { btnUseAbilityP2.addActionListener(listener); }
     public void addRematchListener(ActionListener listener) { btnRematch.addActionListener(listener); }
     public void addReturnListener(ActionListener listener) { btnReturn.addActionListener(listener); }
+
+    /* ----------------------------------------------------- Display Hooks */
+
+    /** Called by the controller at battle start to reset the log and stats. */
+    public void displayBattleStart(Character c1, Character c2) {
+        clearBattleLog();
+        appendToBattleLog("Battle begins: " + c1.getName() + " vs " + c2.getName());
+        updatePlayer1Stats();
+        updatePlayer2Stats();
+    }
+
+    /** Updates the battle log with the latest turn results. */
+    public void displayTurnResults(model.battle.CombatLog log) {
+        log.getLogEntries().forEach(this::appendToBattleLog);
+        updatePlayer1Stats();
+        updatePlayer2Stats();
+    }
+
+    /** Announces the winner at the end of the battle. */
+    public void displayBattleEnd(Character winner) {
+        appendToBattleLog(winner.getName() + " wins the battle!");
+    }
 }


### PR DESCRIPTION
## Summary
- wire up battle consumables with new `SingleUseEffectType`
- extend `SingleUseItem` with effect data and application logic
- update `MagicItemFactory` to build items with effects
- execute and log item effects from `BattleController`
- add simple display hooks to `BattleView`

## Testing
- `javac $(find . -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6882cd68c4048328a120e87e7ff34dde