### PR TITLE
Refactor SaveLoadService paths

### DIFF
--- a/persistence/SaveLoadService.java
+++ b/persistence/SaveLoadService.java
@@ -3,6 +3,7 @@ package persistence;
 import model.core.Player;
 import model.core.HallOfFameEntry;
 import model.util.GameException;
+import model.util.Constants;
 import java.io.*;
 import java.util.List;
 import java.util.ArrayList;
@@ -10,8 +11,8 @@ import java.util.ArrayList;
 public class SaveLoadService {
 
     // File paths for saving and loading game data
-    private static final String GAME_DATA_FILE = "game_data.dat"; 
-    private static final String HALL_OF_FAME_FILE = "hall_of_fame.dat"; 
+    private static final String GAME_DATA_FILE = Constants.SAVE_FILE_PATH;
+    private static final String HALL_OF_FAME_FILE = Constants.HALL_OF_FAME_SAVE_PATH;
 
     // Saves the game data to a file
     public static void saveGame(GameData gameData) throws GameException {

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,11 @@
+# Test Instructions
+
+Compile all test sources and application sources:
+
+```bash
+javac $(find .. -name '*.java')
+```
+
+Run individual tests with `java` followed by the class name.
+
+The save and hall of fame files are defined by `Constants.SAVE_FILE_PATH` and `Constants.HALL_OF_FAME_SAVE_PATH` in `model.util.Constants`.


### PR DESCRIPTION
## Summary
- reference centralized save file path constants
- document testing instructions referencing constants

## Testing
- `javac persistence/SaveLoadService.java`
- `javac MainMenuTest.java` *(fails: cannot find symbol BattleView, SimpleBot, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6882da3050d48328925d162815c232e5