### PR TITLE
Fix GameManagerController imports

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -9,6 +9,11 @@ import persistence.GameData;
 import persistence.SaveLoadService;
 import view.*;
 import app.Main;
+import model.util.RandomCharacterGenerator;
+import model.util.SimpleBot;
+import model.util.Constants;
+import model.item.MagicItem;
+import model.service.MagicItemFactory;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;


### PR DESCRIPTION
## Summary
- add missing imports for `RandomCharacterGenerator`, `SimpleBot`, `Constants`, `MagicItem` and `MagicItemFactory`

## Testing
- `javac controller/GameManagerController.java` *(fails: `setPlayer2ControlsEnabled` symbol not found in SceneManager)*

------
https://chatgpt.com/codex/tasks/task_e_6882da2b64008328a7d75efe3cadf33b