### PR TITLE
Enforce unique player names on registration

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -200,7 +200,7 @@ public void actionPerformed(ActionEvent e) {
     }
 
 
-     public void handleRegisterPlayers(String player1Name, String player2Name) {
+    public boolean handleRegisterPlayers(String player1Name, String player2Name) {
     boolean hasConflict = false;
     StringBuilder errorMsg = new StringBuilder();
 
@@ -236,8 +236,10 @@ public void actionPerformed(ActionEvent e) {
         gameData.setAllPlayers(existing);
         SaveLoadService.saveGame(gameData);
         System.out.println("Players " + player1Name + " and " + player2Name + " have been registered.");
+        return true;
     } else {
         JOptionPane.showMessageDialog(null, errorMsg.toString(), "Player Registration Error", JOptionPane.ERROR_MESSAGE);
+        return false;
     }
 }
 

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -105,18 +105,22 @@ public final class SceneManager {
                                 "Error", JOptionPane.ERROR_MESSAGE);
                     } else {
                         // Register the players and save them to the file
-                        GameManagerController controller = new GameManagerController(this, 
-                                new HallOfFameController(new HallOfFameManagementView()), mainMenuView);
-                        controller.handleRegisterPlayers(player1Name, player2Name); // Save the players
+                        boolean registered = gameManagerController.handleRegisterPlayers(player1Name, player2Name);
 
-                        // Show confirmation message
-                        JOptionPane.showMessageDialog(playerRegView, "Players Registered: " + player1Name + " and " + player2Name, 
-                                "Success", JOptionPane.INFORMATION_MESSAGE);
+                        if (registered) {
+                            // Show confirmation message
+                            JOptionPane.showMessageDialog(playerRegView,
+                                    "Players Registered: " + player1Name + " and " + player2Name,
+                                    "Success", JOptionPane.INFORMATION_MESSAGE);
 
-                        System.out.println("Players Registered: " + player1Name + " and " + player2Name);
+                            System.out.println("Players Registered: " + player1Name + " and " + player2Name);
 
-                        // After successful registration, return to the main menu
-                        showMainMenu(); 
+                            // After successful registration, return to the main menu
+                            showMainMenu();
+                        } else {
+                            // Clear the fields so the user can try again
+                            playerRegView.resetFields();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- return success flag from `handleRegisterPlayers`
- check result in `SceneManager.showPlayerRegistration`
- clear input fields when registration fails so players can try again

## Testing
- `javac $(find . -name '*.java' ! -path './src/test/*' ! -path './tests/*')`
- `mvn -q test` *(fails: Plugin resolution due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688305eeae1c8328b1586c1da60f62b6