### PR TITLE
Persist registered players across sessions

### DIFF
--- a/model/core/Ability.java
+++ b/model/core/Ability.java
@@ -4,12 +4,15 @@ import model.util.Constants;
 import model.util.GameException;
 import model.util.InputValidator;
 import model.util.StatusEffectType;
+import java.io.Serializable;
 
 /**
  * Represents a combat ability (attack, heal, or status effect).
  * Immutable and metadata-driven. Holds no executable logic.
  */
-public final class Ability {
+public final class Ability implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final String name;
     private final String description;

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -8,6 +8,7 @@ import model.util.GameException;
 import model.util.InputValidator;
 import model.util.StatusEffect;
 import model.util.StatusEffectType;
+import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,7 +21,9 @@ import java.util.List;
  * inventory, abilities, and status effects. It is responsible for enforcing
  * the game's mechanical constraints on its own state.
  */
-public class Character {
+public class Character implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     // --- Core Immutable Attributes ---
     private final String name;
@@ -30,7 +33,7 @@ public class Character {
     // --- Core Mutable Attributes ---
     private final List<Ability> abilities;
     private final Inventory inventory;
-    private final List<StatusEffect> activeStatusEffects;
+    private final transient List<StatusEffect> activeStatusEffects;
     private MagicItem equippedItem;
 
     // --- Dynamic Stats ---

--- a/model/core/HallOfFameEntry.java
+++ b/model/core/HallOfFameEntry.java
@@ -2,6 +2,7 @@ package model.core;
 
 import model.util.GameException;
 import model.util.InputValidator;
+import java.io.Serializable;
 
 /**
  * Data Transfer Object (DTO) representing a single Hall of Fame leaderboard entry.
@@ -9,7 +10,9 @@ import model.util.InputValidator;
  * <p>Stores immutable player identity and mutable win count.
  * Designed for display purposes and simple cumulative tracking.</p>
  */
-public final class HallOfFameEntry {
+public final class HallOfFameEntry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /** Player's display name (immutable). */
     private final String playerName;

--- a/model/core/Player.java
+++ b/model/core/Player.java
@@ -9,7 +9,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public final class Player {
+import java.io.Serializable;
+
+public final class Player implements Serializable {
+
+    private static final long serialVersionUID = 1L;
     private final String name;
     private final List<Character> characters;
     private int cumulativeWins;

--- a/model/item/Inventory.java
+++ b/model/item/Inventory.java
@@ -6,6 +6,7 @@ import model.util.InputValidator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.io.Serializable;
 
 /**
  * Represents a character's inventory of magic items in <i>Fatal Fantasy: Tactics</i>.
@@ -22,7 +23,9 @@ import java.util.List;
  * <li><strong>MCO2 Core:</strong> Magic Item System (inventory, equipment, consumption).</li>
  * </ul>
  */
-public final class Inventory {
+public final class Inventory implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /** A unified list of all magic items the character possesses. */
     private final List<MagicItem> items;

--- a/model/item/MagicItem.java
+++ b/model/item/MagicItem.java
@@ -2,6 +2,7 @@ package model.item;
 
 import model.util.GameException;
 import model.util.InputValidator;
+import java.io.Serializable;
 
 /**
  * <h2>MagicItem</h2>
@@ -26,7 +27,9 @@ import model.util.InputValidator;
  * @see SingleUseItem
  * @see Inventory
  */
-public abstract class MagicItem {
+public abstract class MagicItem implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /** Human-friendly item title (non-blank). */
     private final String name;

--- a/persistence/GameData.java
+++ b/persistence/GameData.java
@@ -29,11 +29,10 @@ public class GameData implements Serializable {
     /* Fields (UML-specified)                                             */
     /* ------------------------------------------------------------------ */
 
-    // Mark transient to avoid serialization warnings when contained types
-    // are not themselves serializable. On deserialization these fields are
-    // reinitialised to empty lists.
-    private transient List<Player>          allPlayers;
-    private transient List<HallOfFameEntry> hallOfFame;
+    // Lists of all players and Hall of Fame entries.
+    // Serialized directly now that model classes implement Serializable.
+    private List<Player>          allPlayers;
+    private List<HallOfFameEntry> hallOfFame;
 
     /* ------------------------------------------------------------------ */
     /* Constructors                                                       */


### PR DESCRIPTION
## Summary
- mark core model classes as `Serializable`
- remove transient keywords from saved lists

This allows `SaveLoadService` to persist players and other game data so that registered players remain available after restarting the game.

## Testing
- `javac $(find app model controller view persistence -name '*.java')`
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688313bb2d888328b0d671e92c19a99d