### PR TITLE
Add full character management actions

### DIFF
--- a/controller/CharacterAutoCreationController.java
+++ b/controller/CharacterAutoCreationController.java
@@ -92,6 +92,9 @@ public final class CharacterAutoCreationController {
                 newCharacter.setAbilities(abilities);
 
                 player.addCharacter(newCharacter);
+                // Persist the updated roster immediately
+                gameManagerController.handleSaveGameRequest();
+
                 view.showInfoMessage("Character \"" + name + "\" created successfully!");
                 view.dispose();
             }

--- a/controller/CharacterManualCreationController.java
+++ b/controller/CharacterManualCreationController.java
@@ -131,6 +131,9 @@ public final class CharacterManualCreationController {
             Player player = getPlayerByName(this.playerName);
             player.addCharacter(newCharacter);
 
+            // Persist the updated game data
+            gameManagerController.handleSaveGameRequest();
+
             view.showInfoMessage("Character \"" + name + "\" successfully created!");
             view.dispose();
 

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -1,7 +1,12 @@
 package controller;
 
+import model.core.Ability;
 import model.core.Character;
+import model.core.ClassType;
 import model.core.Player;
+import model.item.MagicItem;
+import model.service.ClassService;
+import model.util.GameException;
 import view.*;
 
 import java.awt.event.ActionListener;
@@ -13,6 +18,7 @@ public class PlayerCharacterManagementController {
     private final PlayerCharacterManagementView view;
     private final Player player;
     private final GameManagerController gameManagerController;
+    private final ClassService classService = ClassService.INSTANCE;
 
     public PlayerCharacterManagementController(PlayerCharacterManagementView view,
                                                Player player,
@@ -40,7 +46,12 @@ public class PlayerCharacterManagementController {
     private void openCharacterList() {
         CharacterListViewingView listView = new CharacterListViewingView(view.getPlayerID());
         listView.setActionListener(e -> {
-            if (CharacterListViewingView.RETURN.equals(e.getActionCommand())) listView.dispose();
+            String cmd = e.getActionCommand();
+            if (CharacterListViewingView.RETURN.equals(cmd)) {
+                listView.dispose();
+            } else if (CharacterListViewingView.VIEW_CHAR.equals(cmd)) {
+                openCharacterSpecView();
+            }
         });
         refreshCharacterList(listView);
     }
@@ -60,12 +71,124 @@ public class PlayerCharacterManagementController {
         dv.setCharacterOptions(chars.stream().map(Character::getName).toArray(String[]::new));
     }
 
+    private void openCharacterSpecView() {
+        CharacterSpecViewingView specView = new CharacterSpecViewingView(view.getPlayerID());
+        specView.setCharacterOptions(player.getCharacters().stream()
+                .map(Character::getName).toArray(String[]::new));
+        specView.setActionListener(e -> {
+            String cmd = e.getActionCommand();
+            if (CharacterSpecViewingView.RETURN.equals(cmd)) {
+                specView.dispose();
+            } else {
+                String name = specView.getSelectedCharacter();
+                Character c = player.getCharacter(name).orElse(null);
+                String details = (c == null) ? "Character not found." : c.toString() + "\nAbilities:\n" +
+                        c.getAbilities().stream().map(Ability::getName).collect(Collectors.joining("\n"));
+                specView.updateCharacterDetails(details);
+            }
+        });
+        specView.resetView();
+    }
+
     private void openEditCharacter() {
         CharacterEditView editView = new CharacterEditView(view.getPlayerID());
+
+        editView.setCharacterOptions(player.getCharacters().stream()
+                .map(Character::getName).toArray(String[]::new));
+
         editView.setActionListener(e -> {
-            if (CharacterEditView.RETURN.equals(e.getActionCommand())) editView.dispose();
+            String cmd = e.getActionCommand();
+            if (CharacterEditView.RETURN.equals(cmd)) {
+                editView.dispose();
+            } else if (CharacterEditView.EDIT.equals(cmd)) {
+                handleEditConfirmation(editView);
+            } else if (e.getSource() == editView.getCharacterDropdown()) {
+                populateEditFields(editView);
+            }
         });
-        // editing logic not fully implemented
+
+        populateEditFields(editView);
+    }
+
+    private void populateEditFields(CharacterEditView ev) {
+        String name = ev.getSelectedCharacter();
+        if (name == null) {
+            ev.resetFields();
+            return;
+        }
+
+        Character c = player.getCharacter(name).orElse(null);
+        if (c == null) return;
+
+        List<String> abilityNames;
+        try {
+            abilityNames = classService.getAvailableAbilities(c.getClassType())
+                    .stream().map(Ability::getName).toList();
+        } catch (GameException ex) {
+            abilityNames = List.of();
+        }
+        String[] opts = abilityNames.toArray(new String[0]);
+        ev.setAbilityOptions(1, opts);
+        ev.setAbilityOptions(2, opts);
+        ev.setAbilityOptions(3, opts);
+
+        List<Ability> current = c.getAbilities();
+        if (current.size() >= 3) {
+            ev.setSelectedAbility(1, current.get(0).getName());
+            ev.setSelectedAbility(2, current.get(1).getName());
+            ev.setSelectedAbility(3, current.get(2).getName());
+        }
+
+        List<MagicItem> items = c.getInventory().getAllItems();
+        String[] itemNames = new String[items.size() + 1];
+        itemNames[0] = "None";
+        for (int i = 0; i < items.size(); i++) {
+            itemNames[i + 1] = items.get(i).getName();
+        }
+        ev.setMagicItemOptions(itemNames);
+        MagicItem equipped = c.getEquippedItem();
+        ev.setSelectedMagicItem(equipped != null ? equipped.getName() : "None");
+    }
+
+    private void handleEditConfirmation(CharacterEditView ev) {
+        String charName = ev.getSelectedCharacter();
+        if (charName == null) {
+            ev.showErrorMessage("No character selected.");
+            return;
+        }
+
+        if (!ev.confirmCharacterEdit(charName)) {
+            return;
+        }
+
+        Character c = player.getCharacter(charName).orElse(null);
+        if (c == null) {
+            ev.showErrorMessage("Character not found.");
+            return;
+        }
+
+        try {
+            List<Ability> newAbilities = classService.getAbilitiesByNames(ev.getSelectedAbilities());
+            c.setAbilities(newAbilities);
+
+            String itemName = ev.getSelectedMagicItem();
+            if (itemName == null || itemName.equals("None")) {
+                c.unequipItem();
+            } else {
+                for (MagicItem mi : c.getInventory().getAllItems()) {
+                    if (mi.getName().equalsIgnoreCase(itemName)) {
+                        c.equipItem(mi);
+                        break;
+                    }
+                }
+            }
+
+            gameManagerController.handleSaveGameRequest();
+            ev.showInfoMessage("Character updated.");
+            ev.dispose();
+        } catch (GameException ex) {
+            ev.showErrorMessage(ex.getMessage());
+        }
     }
 
     private void openDeleteCharacter() {
@@ -80,6 +203,7 @@ public class PlayerCharacterManagementController {
                     if (player.removeCharacter(name)) {
                         delView.showInfoMessage("Deleted " + name);
                         refreshCharacterList(delView);
+                        gameManagerController.handleSaveGameRequest();
                     } else {
                         delView.showErrorMessage("Character not found");
                     }

--- a/view/CharacterEditView.java
+++ b/view/CharacterEditView.java
@@ -167,6 +167,23 @@ public class CharacterEditView extends JFrame {
         for (String item : items) dropdownMagicItem.addItem(item);
     }
 
+    public void setSelectedAbility(int slot, String abilityName) {
+        JComboBox<String> target = switch (slot) {
+            case 1 -> dropdownAbility1;
+            case 2 -> dropdownAbility2;
+            case 3 -> dropdownAbility3;
+            default -> throw new IllegalArgumentException("Invalid slot: " + slot);
+        };
+        target.setSelectedItem(abilityName);
+    }
+
+    public void setSelectedMagicItem(String itemName) {
+        dropdownMagicItem.setSelectedItem(itemName);
+    }
+
+    public JComboBox<String> getCharacterDropdown() { return dropdownCharacter; }
+    public JComboBox<String> getMagicItemDropdown() { return dropdownMagicItem; }
+
     public void resetFields() {
         dropdownCharacter.setSelectedIndex(-1);
         dropdownAbility1.setSelectedIndex(-1);


### PR DESCRIPTION
## Summary
- persist created characters in manual & auto creation
- expand player character management controller to support viewing details, editing abilities/equipment and deleting with save
- extend edit view with helper methods for selection

## Testing
- `mvn test` *(fails: Plugin resolution due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688317888ff0832889f9f4660fb96b27