### PR TITLE
Fix initialization crashes with null selection & race bonuses

### DIFF
--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -81,6 +81,10 @@ public class PlayerCharacterManagementController {
                 specView.dispose();
             } else {
                 String name = specView.getSelectedCharacter();
+                // ignore events where no character is selected
+                if (name == null || name.isBlank()) {
+                    return;
+                }
                 Character c = player.getCharacter(name).orElse(null);
                 String details = (c == null) ? "Character not found." : c.toString() + "\nAbilities:\n" +
                         c.getAbilities().stream().map(Ability::getName).collect(Collectors.joining("\n"));

--- a/model/service/RaceService.java
+++ b/model/service/RaceService.java
@@ -93,8 +93,9 @@ public final class RaceService {
         EnumMap<RaceType, RaceBonus> map = new EnumMap<>(RaceType.class);
         map.put(RaceType.HUMAN , new RaceBonus(0 ,  0, 0));
         map.put(RaceType.ELF   , new RaceBonus(0 , 10, 1));
-        map.put(RaceType.GNOME , new RaceBonus(-5, 15, 1));
-        map.put(RaceType.DWARF , new RaceBonus(20, -5, 0));
+        // Negative bonuses violate validation constraints; use zero instead
+        map.put(RaceType.GNOME , new RaceBonus(0 , 15, 1));
+        map.put(RaceType.DWARF , new RaceBonus(20, 0, 0));
         return map;
     }
 }


### PR DESCRIPTION
## Summary
- avoid negative values when initializing race bonuses
- guard against blank selection in character spec view to prevent errors

## Testing
- `mvn test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68832629f8c483289183e98332a16aa4