### PR TITLE
Fix shuffle error for ability randomization

### DIFF
--- a/model/service/ClassService.java
+++ b/model/service/ClassService.java
@@ -164,7 +164,7 @@ public final class ClassService {
      * @return List of random Ability instances
      */
     public List<Ability> getRandomAbilitiesForClass(ClassType classType, int count) {
-        List<Ability> all = getAvailableAbilities(classType);
+        List<Ability> all = new ArrayList<>(getAvailableAbilities(classType));
         Collections.shuffle(all); // Randomize the order
         return all.stream().limit(count).collect(Collectors.toList());
     }


### PR DESCRIPTION
## Summary
- create modifiable list before shuffling abilities

## Testing
- `mvn -q -o test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6883582baca88328b8c77569b0cedf4f