### PR TITLE
Integrate win handling in battle controller

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -127,7 +127,7 @@ public void actionPerformed(ActionEvent e) {
                 try {
                     Character bot = RandomCharacterGenerator.generate("Bot");
                     AIController ai = new AIController(new SimpleBot(new java.util.Random()));
-                    sceneManager.showPlayerVsBotBattle(human, bot, ai);
+                    sceneManager.showPlayerVsBotBattle(player, human, bot, ai);
                     mainMenuView.dispose();
                 } catch (GameException e1) {
                     JOptionPane.showMessageDialog(mainMenuView, "Failed to start battle: " + e1.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -220,11 +220,11 @@ public final class SceneManager {
     }
 
     /** Displays a battle between two characters. */
-    public void showPlayerVsBotBattle(Character human, Character bot, AIController aiController) {
+    public void showPlayerVsBotBattle(Player humanPlayer, Character human, Character bot, AIController aiController) {
         battleView = new BattleView(human, bot);
         battleView.setPlayer2ControlsEnabled(false);
         try {
-            BattleController battleController = new BattleController(battleView);
+            BattleController battleController = new BattleController(battleView, gameManagerController, humanPlayer, null);
             battleView.addUseAbilityP1Listener(e -> {
                 int idx = battleView.getAbilitySelectorP1().getSelectedIndex();
                 if (idx >= 0) {


### PR DESCRIPTION
## Summary
- allow `BattleController` to track owning players and `GameManagerController`
- award XP and persist wins when a battle ends
- refresh UI when items are consumed
- wire SceneManager and GameManagerController to pass player info

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download Maven plugin)*
- `mvn -q test` *(fails: Could not download Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6883d4a5e5248328bd3f5f3f264123f5