### PR TITLE
Fix BattleView initialization

### DIFF
--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -235,13 +235,15 @@ public final class SceneManager {
                     }
                 }
             });
-            battleView.addReturnListener(e -> cards.show(root, CARD_MAIN_MENU));
-            root.add(battleView, CARD_BATTLE);
+            battleView.addReturnListener(e -> {
+                battleView.dispose();
+                showMainMenu();
+            });
             battleController.startBattleVsBot(human, bot, aiController);
         } catch (GameException e) {
             JOptionPane.showMessageDialog(stage, "Unable to start battle: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            battleView.dispose();
         }
-        cards.show(root, CARD_BATTLE);
     }
 
     /** Entry point for testing this class in isolation. */


### PR DESCRIPTION
## Summary
- launch `BattleView` as its own frame
- dispose the battle window on return

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6883d701abdc8328af6f7ddbc35df17e