### PR TITLE
Cleanup direct view disposal

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -104,19 +104,16 @@ public void actionPerformed(ActionEvent e) {
     switch (command) {
         case MainMenuView.REGISTER_PLAYERS -> {
             sceneManager.showPlayerRegistration(); // Shows Player Registration View
-            mainMenuView.dispose(); // Close the MainMenuView
         }
         case MainMenuView.MANAGE_CHARACTERS -> {
             if (players.isEmpty()) {
                 JOptionPane.showMessageDialog(mainMenuView, "Please register players first.", "Error", JOptionPane.ERROR_MESSAGE);
             } else {
                 sceneManager.showCharacterManagementMenu(players);
-                mainMenuView.dispose();
             }
         }
         case MainMenuView.HALL_OF_FAME -> {
             sceneManager.showHallOfFameManagement(); // Show Hall of Fame View
-            mainMenuView.dispose(); // Close the MainMenuView
         }
         case MainMenuView.START_BATTLE -> {
             if (players.isEmpty() || players.get(0).getCharacters().isEmpty()) {
@@ -128,7 +125,6 @@ public void actionPerformed(ActionEvent e) {
                     Character bot = RandomCharacterGenerator.generate("Bot");
                     AIController ai = new AIController(new SimpleBot(new java.util.Random()));
                     sceneManager.showPlayerVsBotBattle(player, human, bot, ai);
-                    mainMenuView.dispose();
                 } catch (GameException e1) {
                     JOptionPane.showMessageDialog(mainMenuView, "Failed to start battle: " + e1.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
                 }
@@ -161,21 +157,17 @@ public void actionPerformed(ActionEvent e) {
                 switch (command) {
                     case CharacterCreationManagementView.MANUAL_CREATION -> {
                         handleNavigateToManualCreation(playerName);
-                        view.dispose();
                     }
                     case CharacterCreationManagementView.AUTO_CREATION -> {
                         handleNavigateToAutoCreation(playerName);
-                        view.dispose();
                     }
                     case CharacterCreationManagementView.RETURN -> {
                         navigateBackToMainMenu();
-                        view.dispose();
                     }
                 }
             });
 
-            // Ensure the menu becomes visible when opened
-            view.setVisible(true);
+            // Menu is visible upon creation
         });
     }
 
@@ -185,7 +177,6 @@ public void actionPerformed(ActionEvent e) {
         SwingUtilities.invokeLater(() -> {
             CharacterManualCreationView manualView = new CharacterManualCreationView(playerId);
             new CharacterManualCreationController(manualView, playerName, this);
-            manualView.setVisible(true);
         });
     }
 
@@ -194,7 +185,6 @@ public void actionPerformed(ActionEvent e) {
         SwingUtilities.invokeLater(() -> {
             CharacterAutoCreationView autoView = new CharacterAutoCreationView(playerId);
             new CharacterAutoCreationController(autoView, playerName, this);
-            autoView.setVisible(true);
         });
     }
 
@@ -310,7 +300,6 @@ public void actionPerformed(ActionEvent e) {
      */
     private void quitApplication() {
         handleSaveGameRequest();
-        mainMenuView.dispose();
         Main.shutdown();
     }
 

--- a/controller/HallOfFameController.java
+++ b/controller/HallOfFameController.java
@@ -9,6 +9,7 @@ import model.core.Player;
 import model.core.HallOfFameEntry;
 import model.util.GameException;
 import model.util.InputValidator;
+import controller.SceneManager;
 import persistence.SaveLoadService;
 import view.HallOfFameCharactersView;
 import view.HallOfFamePlayersView;
@@ -21,11 +22,14 @@ import view.HallOfFameManagementView;
 public class HallOfFameController implements ActionListener {
 
     private final HallOfFameManagementView view;
+    private final SceneManager sceneManager;
     private List<HallOfFameEntry> hallOfFameEntries;
 
-    public HallOfFameController(HallOfFameManagementView view) {
+    public HallOfFameController(HallOfFameManagementView view, SceneManager sceneManager) {
         InputValidator.requireNonNull(view, "view");
+        InputValidator.requireNonNull(sceneManager, "sceneManager");
         this.view = view;
+        this.sceneManager = sceneManager;
 
         try {
             this.hallOfFameEntries = SaveLoadService.loadHallOfFame();
@@ -40,14 +44,12 @@ public class HallOfFameController implements ActionListener {
     private void showTopPlayers() {
         HallOfFamePlayersView playersView = new HallOfFamePlayersView();
         bindHallOfFamePlayersView(playersView);
-        playersView.setVisible(true);
     }
 
     /** Opens the Top Characters subview and displays leaderboard data. */
     private void showTopCharacters() {
         HallOfFameCharactersView charactersView = new HallOfFameCharactersView();
         bindHallOfFameCharactersView(charactersView);
-        charactersView.setVisible(true);
     }
 
     /** Adds a win to the specified player in the Hall of Fame. */
@@ -101,7 +103,8 @@ public class HallOfFameController implements ActionListener {
 
         view.setActionListener(e -> {
             if (HallOfFameCharactersView.RETURN.equals(e.getActionCommand())) {
-                view.dispose();
+                sceneManager.closeWindow(view);
+                sceneManager.showHallOfFameManagement();
             }
         });
 
@@ -126,7 +129,8 @@ public class HallOfFameController implements ActionListener {
 
         view.setActionListener(e -> {
             if (HallOfFamePlayersView.RETURN.equals(e.getActionCommand())) {
-                view.dispose();
+                sceneManager.closeWindow(view);
+                sceneManager.showHallOfFameManagement();
             }
         });
 
@@ -152,7 +156,7 @@ public class HallOfFameController implements ActionListener {
         switch (command) {
             case HallOfFameManagementView.TOP_PLAYERS -> showTopPlayers();
             case HallOfFameManagementView.TOP_CHARACTERS -> showTopCharacters();
-            case HallOfFameManagementView.RETURN -> view.dispose();
+            case HallOfFameManagementView.RETURN -> sceneManager.showMainMenu();
             default -> view.showErrorMessage("Unknown action: " + command);
         }
     }

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -17,6 +17,7 @@ import persistence.SaveLoadService;
 import view.BattleView;
 import view.CharacterManagementMenuView;
 import view.HallOfFameManagementView;
+import controller.HallOfFameController;
 import view.MainMenuView;
 import view.NewPlayersRegistrationView;
 import view.PlayerCharacterManagementView;
@@ -51,6 +52,7 @@ public final class SceneManager {
     private BattleView battleView;
 
     private GameManagerController gameManagerController; // Keep the controller instance here
+    private HallOfFameController hallOfFameController;
 
     // ---------- Constructor ----------
     public SceneManager() {
@@ -76,10 +78,18 @@ public final class SceneManager {
         if (mainMenuView == null) {
             mainMenuView = new MainMenuView();
 
-            // Initialize the controller only once
-            
+            if (hallOfFameView == null) {
+                hallOfFameView = new HallOfFameManagementView();
+            }
+
+            if (hallOfFameController == null) {
+                hallOfFameController = new HallOfFameController(hallOfFameView, this);
+                hallOfFameView.setActionListener(hallOfFameController);
+                root.add(hallOfFameView.getContentPane(), CARD_HALL_OF_FAME);
+            }
+
             if (gameManagerController == null) {
-                gameManagerController = new GameManagerController(this, new HallOfFameController(hallOfFameView), mainMenuView);
+                gameManagerController = new GameManagerController(this, hallOfFameController, mainMenuView);
             }
             mainMenuView.setActionListener(gameManagerController);
             root.add(mainMenuView.getContentPane(), CARD_MAIN_MENU);
@@ -178,8 +188,8 @@ public final class SceneManager {
     public void showHallOfFameManagement() {
         if (hallOfFameView == null) {
             hallOfFameView = new HallOfFameManagementView();
-            HallOfFameController controller = new HallOfFameController(hallOfFameView);
-            hallOfFameView.setActionListener(controller);
+            hallOfFameController = new HallOfFameController(hallOfFameView, this);
+            hallOfFameView.setActionListener(hallOfFameController);
             root.add(hallOfFameView.getContentPane(), CARD_HALL_OF_FAME);
         }
         cards.show(root, CARD_HALL_OF_FAME);
@@ -255,6 +265,13 @@ public final class SceneManager {
     /** Entry point for testing this class in isolation. */
     public static void main(String[] args) {
         SwingUtilities.invokeLater(SceneManager::new);
+    }
+
+    /** Closes any standalone window. */
+    public void closeWindow(java.awt.Window window) {
+        if (window != null) {
+            window.dispose();
+        }
     }
 
     /** Launches the main menu — for external triggering. */


### PR DESCRIPTION
## Summary
- route main menu actions through `SceneManager` without disposing views
- inject `SceneManager` into `HallOfFameController` and centralize closing pop‑ups
- initialize Hall of Fame scene and controller in `SceneManager`
- expose `SceneManager.closeWindow` helper

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688471f97d788328afe8dd816fd1ed75