### PR TITLE
Update tests for JPanel-based views

### DIFF
--- a/src/test/java/controller/BattleControllerTest.java
+++ b/src/test/java/controller/BattleControllerTest.java
@@ -11,7 +11,6 @@ import view.BattleView;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.swing.*;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/controller/GameManagerPersistenceTest.java
+++ b/src/test/java/controller/GameManagerPersistenceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import persistence.GameData;
 import persistence.SaveLoadService;
 
-import javax.swing.JFrame;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -31,11 +30,13 @@ public class GameManagerPersistenceTest {
         f.setAccessible(true);
         GameManagerController controller = (GameManagerController) f.get(sm);
 
-        // Dispose the frame to avoid GUI leftovers
+        // Dispose the stage if present to avoid GUI leftovers in headless mode
         Field stageField = SceneManager.class.getDeclaredField("stage");
         stageField.setAccessible(true);
-        JFrame stage = (JFrame) stageField.get(sm);
-        stage.dispose();
+        Object stage = stageField.get(sm);
+        if (stage instanceof java.awt.Window w) {
+            w.dispose();
+        }
 
         return controller;
     }


### PR DESCRIPTION
## Summary
- adapt tests for view refactor so no JFrame assumptions remain
- clean up imports and ensure stage disposal works when running headless

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688471fad808832881bc127f3f09ee69