### PR TITLE
Ensure HallOfFameController receives a view

### DIFF
--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -76,10 +76,16 @@ public final class SceneManager {
         if (mainMenuView == null) {
             mainMenuView = new MainMenuView();
 
+            // Ensure Hall of Fame view exists before creating its controller
+            if (hallOfFameView == null) {
+                hallOfFameView = new HallOfFameManagementView();
+                root.add(hallOfFameView.getContentPane(), CARD_HALL_OF_FAME);
+            }
+
             // Initialize the controller only once
-            
             if (gameManagerController == null) {
-                gameManagerController = new GameManagerController(this, new HallOfFameController(hallOfFameView), mainMenuView);
+                HallOfFameController hofController = new HallOfFameController(hallOfFameView);
+                gameManagerController = new GameManagerController(this, hofController, mainMenuView);
             }
             mainMenuView.setActionListener(gameManagerController);
             root.add(mainMenuView.getContentPane(), CARD_MAIN_MENU);


### PR DESCRIPTION
## Summary
- create the Hall of Fame view before constructing its controller
- add the Hall of Fame card at startup

## Testing
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688471fda438832889576b05eb221b57