### PR TITLE
Refactor views to use JPanel

### DIFF
--- a/view/BattleCharSelectionView.java
+++ b/view/BattleCharSelectionView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The battle character selection view for Fatal Fantasy: Tactics Game.
  */
-public class BattleCharSelectionView extends JFrame {
+public class BattleCharSelectionView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -27,34 +27,13 @@ public class BattleCharSelectionView extends JFrame {
      * Constructs the Battle Character Selection UI of Fatal Fantasy: Tactics Game.
      */
     public BattleCharSelectionView(int playerID) {
-        super(getTitleForPlayer(playerID));
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    BattleCharSelectionView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -181,7 +160,8 @@ public class BattleCharSelectionView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/BattleModesView.java
+++ b/view/BattleModesView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The battle modes view for Fatal Fantasy: Tactics Game.
  */
-public class BattleModesView extends JFrame {
+public class BattleModesView extends JPanel {
     // Button labels
     public static final String PLAYER_VS_PLAYER = "Player vs Player";
     public static final String PLAYER_VS_BOT = "Player vs Bot";
@@ -25,32 +25,11 @@ public class BattleModesView extends JFrame {
      * Constructs the Battle Mode Selection UI of Fatal Fantasy: Tactics Game.
      */
     public BattleModesView() {
-        super("Fatal Fantasy: Tactics | Battle Mode Selection");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    BattleModesView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -118,7 +97,8 @@ public class BattleModesView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The battle view for Fatal Fantasy: Tactics Game.
  */
-public class BattleView extends JFrame {
+public class BattleView extends JPanel {
     public static final int BATTLE_PVP = 1;
     public static final int BATTLE_PVB = 2;
 
@@ -34,34 +34,13 @@ public class BattleView extends JFrame {
      * Constructs the Battle UI of Fatal Fantasy: Tactics Game.
      */
     public BattleView(int mode) {
-        super(getTitleForPlayer(mode));
 
         this.mode = mode;
 
         initUI();
         
-        setSize(1200, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    BattleView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -189,7 +168,8 @@ public class BattleView extends JFrame {
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
     /**

--- a/view/CharacterAutoCreationView.java
+++ b/view/CharacterAutoCreationView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The automatic character creation view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterAutoCreationView extends JFrame {
+public class CharacterAutoCreationView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -28,34 +28,13 @@ public class CharacterAutoCreationView extends JFrame {
      * Constructs the Automatic Character Creation UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterAutoCreationView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Automatic Character Creation");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterAutoCreationView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -155,7 +134,8 @@ public class CharacterAutoCreationView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
     

--- a/view/CharacterCreationManagementView.java
+++ b/view/CharacterCreationManagementView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character creation management menu view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterCreationManagementView extends JFrame {
+public class CharacterCreationManagementView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -27,34 +27,13 @@ public class CharacterCreationManagementView extends JFrame {
      * Constructs the Character Creation Management UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterCreationManagementView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Character Creation Modes");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterCreationManagementView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -123,7 +102,8 @@ public class CharacterCreationManagementView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterDeleteView.java
+++ b/view/CharacterDeleteView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character delete view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterDeleteView extends JFrame {
+public class CharacterDeleteView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -27,34 +27,13 @@ public class CharacterDeleteView extends JFrame {
      * Constructs the Specific Character Deletion UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterDeleteView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Character Deletion");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterDeleteView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -167,7 +146,8 @@ public class CharacterDeleteView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterEditView.java
+++ b/view/CharacterEditView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character edit view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterEditView extends JFrame {
+public class CharacterEditView extends JPanel {
 private int playerID;
 
     // Button labels
@@ -29,34 +29,13 @@ private int playerID;
      * Constructs the Manual Character Creation UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterEditView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Character Edit");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterEditView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -129,7 +108,8 @@ private int playerID;
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterListViewingView.java
+++ b/view/CharacterListViewingView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character list view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterListViewingView extends JFrame {
+public class CharacterListViewingView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -26,34 +26,13 @@ public class CharacterListViewingView extends JFrame {
      * Constructs the Character Viewing UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterListViewingView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Characters Viewing");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterListViewingView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -142,7 +121,8 @@ public class CharacterListViewingView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterManagementMenuView.java
+++ b/view/CharacterManagementMenuView.java
@@ -8,7 +8,7 @@ import java.awt.event.ActionListener;
  * First screen for character management where the user selects
  * which player's roster to manage.
  */
-public class CharacterManagementMenuView extends JFrame {
+public class CharacterManagementMenuView extends JPanel {
 
     public static final String MANAGE_PLAYER1 = "Manage Player 1";
     public static final String MANAGE_PLAYER2 = "Manage Player 2";
@@ -19,12 +19,7 @@ public class CharacterManagementMenuView extends JFrame {
     private final JButton btnReturnToMenu = new RoundedButton(RETURN_TO_MENU);
 
     public CharacterManagementMenuView() {
-        super("Character Management");
         initUI();
-        setSize(800, 700);
-        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-        setLocationRelativeTo(null);
-        setResizable(false);
     }
 
     private void initUI() {
@@ -62,7 +57,8 @@ public class CharacterManagementMenuView extends JFrame {
         bgPanel.add(buttonPanel);
         bgPanel.add(Box.createVerticalGlue());
 
-        setContentPane(bgPanel);
+        setLayout(new BorderLayout());
+        add(bgPanel);
     }
 
     public void setActionListener(ActionListener l) {

--- a/view/CharacterManagementView.java
+++ b/view/CharacterManagementView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character management menu view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterManagementView extends JFrame {
+public class CharacterManagementView extends JPanel {
     // Button labels
     public static final String MANAGE_PLAYER1 = "Manage Player 1";
     public static final String MANAGE_PLAYER2 = "Manage Player 2";
@@ -25,32 +25,11 @@ public class CharacterManagementView extends JFrame {
      * Constructs the Character Management UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterManagementView() {
-        super("Fatal Fantasy: Tactics | Character Management");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterManagementView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -118,7 +97,8 @@ public class CharacterManagementView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterManualCreationView.java
+++ b/view/CharacterManualCreationView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The manual character creation view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterManualCreationView extends JFrame {
+public class CharacterManualCreationView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -32,34 +32,13 @@ public class CharacterManualCreationView extends JFrame {
      * Constructs the Manual Character Creation UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterManualCreationView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Manual Character Creation");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterManualCreationView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -142,7 +121,8 @@ public class CharacterManualCreationView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/CharacterSpecViewingView.java
+++ b/view/CharacterSpecViewingView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The character specific view for Fatal Fantasy: Tactics Game.
  */
-public class CharacterSpecViewingView extends JFrame {
+public class CharacterSpecViewingView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -25,34 +25,13 @@ public class CharacterSpecViewingView extends JFrame {
      * Constructs the Specific Character Viewing UI of Fatal Fantasy: Tactics Game.
      */
     public CharacterSpecViewingView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Character Specific Viewing");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    CharacterSpecViewingView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -162,7 +141,8 @@ public class CharacterSpecViewingView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/HallOfFameCharactersView.java
+++ b/view/HallOfFameCharactersView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The top characters view for Fatal Fantasy: Tactics Game.
  */
-public class HallOfFameCharactersView extends JFrame {
+public class HallOfFameCharactersView extends JPanel {
     // Button labels
     public static final String RETURN = "Return";
 
@@ -22,32 +22,11 @@ public class HallOfFameCharactersView extends JFrame {
      * Constructs the Top Characters Viewing UI of Fatal Fantasy: Tactics Game.
      */
     public HallOfFameCharactersView() {
-        super("Fatal Fantasy: Tactics | Top Characters Viewing");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    HallOfFameCharactersView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -133,7 +112,8 @@ public class HallOfFameCharactersView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/HallOfFameManagementView.java
+++ b/view/HallOfFameManagementView.java
@@ -21,7 +21,7 @@ import javax.swing.JPanel;
 /**
  * The hall of fame management view for Fatal Fantasy: Tactics Game.
  */
-public class HallOfFameManagementView extends JFrame {
+public class HallOfFameManagementView extends JPanel {
     // Button labels
     public static final String TOP_PLAYERS = "Top Players";
     public static final String TOP_CHARACTERS = "Top Characters";
@@ -37,31 +37,11 @@ public class HallOfFameManagementView extends JFrame {
      * Constructs the Hall Of Fame Management UI of Fatal Fantasy: Tactics Game.
      */
     public HallOfFameManagementView() {
-        super("Fatal Fantasy: Tactics | Hall Of Fame Management");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    HallOfFameManagementView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
     }
 
 
@@ -129,7 +109,8 @@ public class HallOfFameManagementView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/HallOfFamePlayersView.java
+++ b/view/HallOfFamePlayersView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The top players view for Fatal Fantasy: Tactics Game.
  */
-public class HallOfFamePlayersView extends JFrame {
+public class HallOfFamePlayersView extends JPanel {
     // Button labels
     public static final String RETURN = "Return";
 
@@ -22,32 +22,11 @@ public class HallOfFamePlayersView extends JFrame {
      * Constructs the Top Players Viewing UI of Fatal Fantasy: Tactics Game.
      */
     public HallOfFamePlayersView() {
-        super("Fatal Fantasy: Tactics | Top Players Viewing");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    HallOfFamePlayersView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -133,7 +112,8 @@ public class HallOfFamePlayersView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/InventoryView.java
+++ b/view/InventoryView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The inventory view for Fatal Fantasy: Tactics Game.
  */
-public class InventoryView extends JFrame{
+public class InventoryView extends JPanel{
     private int playerID;
 
     // Button labels
@@ -24,34 +24,13 @@ public class InventoryView extends JFrame{
      * Constructs the Inventory UI of Fatal Fantasy: Tactics Game.
      */
     public InventoryView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Inventory");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    InventoryView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -138,7 +117,8 @@ public class InventoryView extends JFrame{
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/MainMenuView.java
+++ b/view/MainMenuView.java
@@ -21,7 +21,7 @@ import javax.swing.JPanel;
 /**
  * The main menu view for Fatal Fantasy: Tactics Game.
  */
-public class MainMenuView extends JFrame {
+public class MainMenuView extends JPanel {
     // Button labels
     public static final String REGISTER_PLAYERS = "Register Players";
     public static final String MANAGE_CHARACTERS = "Manage Characters";
@@ -41,31 +41,11 @@ public class MainMenuView extends JFrame {
      * Constructs the Main Menu UI of Fatal Fantasy: Tactics Game.
      */
     public MainMenuView() {
-        super("Fatal Fantasy: Tactics | Main Menu");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    MainMenuView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE); // closes all windows
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
     }
 
 
@@ -139,7 +119,8 @@ public class MainMenuView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/NewPlayersRegistrationView.java
+++ b/view/NewPlayersRegistrationView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The new players registration view for Fatal Fantasy: Tactics Game.
  */
-public class NewPlayersRegistrationView extends JFrame {
+public class NewPlayersRegistrationView extends JPanel {
     // Button labels
     public static final String REGISTER = "Register";
     public static final String RETURN = "Return";
@@ -25,32 +25,11 @@ public class NewPlayersRegistrationView extends JFrame {
      * Constructs the NewPlayersRegistrationView UI of Fatal Fantasy: Tactics Game.
      */
     public NewPlayersRegistrationView() {
-        super("Fatal Fantasy: Tactics | New Players Registration");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    NewPlayersRegistrationView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -120,7 +99,8 @@ public class NewPlayersRegistrationView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/PlayerCharManagementView.java
+++ b/view/PlayerCharManagementView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The player character management view for Fatal Fantasy: Tactics Game.
  */
-public class PlayerCharManagementView extends JFrame {
+public class PlayerCharManagementView extends JPanel {
     private int playerID;
 
     // Button labels
@@ -32,34 +32,13 @@ public class PlayerCharManagementView extends JFrame {
      * Constructs the Player Character Management UI of Fatal Fantasy: Tactics Game.
      */
     public PlayerCharManagementView(int playerID) {
-        super("Fatal Fantasy: Tactics | Player " + playerID + " Management");
 
         this.playerID = playerID;
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    PlayerCharManagementView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -137,7 +116,8 @@ public class PlayerCharManagementView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/PlayerCharacterManagementView.java
+++ b/view/PlayerCharacterManagementView.java
@@ -8,7 +8,7 @@ import java.awt.event.ActionListener;
  * Per-player character management menu. Lets the user view, create,
  * edit or delete characters for a specific player.
  */
-public class PlayerCharacterManagementView extends JFrame {
+public class PlayerCharacterManagementView extends JPanel {
 
     public static final String VIEW_CHARACTERS = "View Characters";
     public static final String CREATE_CHARACTER = "Create Character";
@@ -25,13 +25,8 @@ public class PlayerCharacterManagementView extends JFrame {
     private final int playerID;
 
     public PlayerCharacterManagementView(int playerID) {
-        super("Manage Characters - Player " + playerID);
         this.playerID = playerID;
         initUI();
-        setSize(800, 700);
-        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-        setLocationRelativeTo(null);
-        setResizable(false);
     }
 
     private void initUI() {
@@ -74,7 +69,8 @@ public class PlayerCharacterManagementView extends JFrame {
         bgPanel.add(buttonPanel);
         bgPanel.add(Box.createVerticalGlue());
 
-        setContentPane(bgPanel);
+        setLayout(new BorderLayout());
+        add(bgPanel);
     }
 
     public void setActionListener(ActionListener l) {

--- a/view/PlayerDeleteView.java
+++ b/view/PlayerDeleteView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The players deletion view for Fatal Fantasy: Tactics Game.
  */
-public class PlayerDeleteView extends JFrame {
+public class PlayerDeleteView extends JPanel {
 
     // Button labels
     public static final String DELETE = "Delete";
@@ -26,32 +26,11 @@ public class PlayerDeleteView extends JFrame {
      * Constructs the Specific Player Deletion UI of Fatal Fantasy: Tactics Game.
      */
     public PlayerDeleteView() {
-        super("Fatal Fantasy: Tactics | Player Deletion");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    PlayerDeleteView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -163,7 +142,8 @@ public class PlayerDeleteView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/PlayerRegistrationView.java
+++ b/view/PlayerRegistrationView.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 /**
  * The player registration view for Fatal Fantasy: Tactics Game.
  */
-public class PlayerRegistrationView extends JFrame {
+public class PlayerRegistrationView extends JPanel {
     // Button labels
     public static final String NEW_PLAYERS = "New Players";
     public static final String SAVED_PLAYERS = "Saved Players";
@@ -27,32 +27,11 @@ public class PlayerRegistrationView extends JFrame {
      * Constructs the PlayerRegistrationView UI of Fatal Fantasy: Tactics Game.
      */
     public PlayerRegistrationView() {
-        super("Fatal Fantasy: Tactics | Players Registration Menu");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    PlayerRegistrationView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -123,7 +102,8 @@ public class PlayerRegistrationView extends JFrame {
         // Add vertical glue to push everything to the center
         backgroundPanel.add(Box.createVerticalGlue());
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/SavedPlayersRegistrationView.java
+++ b/view/SavedPlayersRegistrationView.java
@@ -27,7 +27,7 @@ import javax.swing.JPanel;
 /**
  * The saved players registration view for Fatal Fantasy: Tactics Game.
  */
-public class SavedPlayersRegistrationView extends JFrame {
+public class SavedPlayersRegistrationView extends JPanel {
     // Button labels
     public static final String REGISTER = "Register";
     public static final String RETURN = "Return";
@@ -43,32 +43,11 @@ public class SavedPlayersRegistrationView extends JFrame {
      * Constructs the SavedPlayersRegistrationView UI of Fatal Fantasy: Tactics Game.
      */
     public SavedPlayersRegistrationView() {
-        super("Fatal Fantasy: Tactics | Saved Players Registration");
 
         initUI();
         
-        setSize(800, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    SavedPlayersRegistrationView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
-        setVisible(true);
     }
 
 
@@ -134,7 +113,8 @@ public class SavedPlayersRegistrationView extends JFrame {
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 

--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -17,7 +17,7 @@ import java.util.List;
  * user selections. All validation and persistence are handled
  * in the controller layer.
  */
-public class TradeView extends JFrame {
+public class TradeView extends JPanel {
 
     public static final String TRADE = "TRADE";
     public static final String CANCEL = "CANCEL";
@@ -37,7 +37,6 @@ public class TradeView extends JFrame {
     private final JButton btnCancel;
 
     public TradeView(Player p1, Player p2) {
-        super("Trade Items");
         this.player1 = p1;
         this.player2 = p2;
 
@@ -57,16 +56,10 @@ public class TradeView extends JFrame {
         btnCancel = new RoundedButton("Cancel");
 
         initUI();
-        configureWindow();
         bindComboListeners();
         refreshLists();
     }
 
-    private void configureWindow() {
-        setSize(600, 400);
-        setLocationRelativeTo(null);
-        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-    }
 
     private void initUI() {
         JPanel main = new JPanel(new BorderLayout());
@@ -91,7 +84,8 @@ public class TradeView extends JFrame {
         main.add(lists, BorderLayout.CENTER);
         main.add(buttons, BorderLayout.SOUTH);
 
-        setContentPane(main);
+        setLayout(new BorderLayout());
+        add(main);
     }
 
     private void bindComboListeners() {

--- a/view/TradingView.java
+++ b/view/TradingView.java
@@ -30,7 +30,7 @@ import javax.swing.JTextArea;
 /**
  * The trading view for Fatal Fantasy: Tactics Game.
  */
-public class TradingView extends JFrame {
+public class TradingView extends JPanel {
 
     // Button labels
     public static final String TRADE = "Trade";
@@ -47,31 +47,11 @@ public class TradingView extends JFrame {
      * Constructs the Trading UI of Fatal Fantasy: Tactics Game.
      */
     public TradingView() {
-        super("Fatal Fantasy: Tactics | Trading");
 
         initUI();
         
-        setSize(1200, 700);
-        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                int choice = JOptionPane.showConfirmDialog(
-                    TradingView.this,
-                    "Are you sure you want to quit?",
-                    "Confirm Exit",
-                    JOptionPane.YES_NO_OPTION
-                );
 
-                if (choice == JOptionPane.YES_OPTION) {
-                    dispose(); // closes the window
-                }
-            }
-        });
-
-        setLocationRelativeTo(null);
-        setResizable(false);
     }
 
 
@@ -162,7 +142,8 @@ public class TradingView extends JFrame {
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
 
 
-        setContentPane(backgroundPanel);
+        setLayout(new BorderLayout());
+        add(backgroundPanel);
     }
 
 


### PR DESCRIPTION
## Summary
- update all views to extend `JPanel` instead of `JFrame`
- remove frame-specific configuration from constructors
- build component hierarchy directly by setting layouts and adding panels

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688471fe87f08328ac4056d89dea82a2