### PR TITLE
Add Player delete workflow

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -351,6 +351,20 @@ public void actionPerformed(ActionEvent e) {
         return Collections.unmodifiableList(players);
     }
 
+    /** Deletes a player with the given name from the current session. */
+    public void deletePlayerByName(String name) throws GameException {
+        InputValidator.requireNonNull(name, "name");
+        boolean removed = players.removeIf(p -> p.getName().equals(name));
+        if (!removed) {
+            throw new GameException("Player not found: " + name);
+        }
+    }
+
+    /** Returns the current game data snapshot for persistence. */
+    public GameData getGameData() throws GameException {
+        return new GameData(players, hallOfFameController.getHallOfFame());
+    }
+
     /** Returns the 1-based index of the player with the given name. */
     private int getPlayerIndexByName(String name) {
         for (int i = 0; i < players.size(); i++) {

--- a/controller/PlayerDeleteController.java
+++ b/controller/PlayerDeleteController.java
@@ -1,0 +1,76 @@
+package controller;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.JOptionPane;
+
+import model.core.Player;
+import persistence.SaveLoadService;
+import view.PlayerDeleteView;
+import model.util.GameException;
+
+/**
+ * Controller handling player deletion workflow.
+ */
+public class PlayerDeleteController implements ActionListener {
+
+    private final PlayerDeleteView view;
+    private final GameManagerController gameManager;
+
+    /**
+     * Constructs a controller for the given view and game manager.
+     */
+    public PlayerDeleteController(PlayerDeleteView view, GameManagerController gameManager) {
+        this.view = view;
+        this.gameManager = gameManager;
+        this.view.setActionListener(this);
+        refresh();
+    }
+
+    /**
+     * Refreshes dropdowns and list text with current players.
+     */
+    public void refresh() {
+        List<Player> players = gameManager.getPlayers();
+        String[] names = players.stream().map(Player::getName).toArray(String[]::new);
+        view.setPlayerOptions(names);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < names.length; i++) {
+            sb.append(i + 1).append(". ").append(names[i]).append("\n");
+        }
+        view.updatePlayerList(sb.toString());
+        view.resetDropdowns();
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String cmd = e.getActionCommand();
+        if (PlayerDeleteView.RETURN.equals(cmd)) {
+            view.dispose();
+            // Back to player registration/main menu handled by SceneManager
+        } else if (PlayerDeleteView.DELETE.equals(cmd)) {
+            String name = view.getSelectedPlayer();
+            if (name == null) {
+                JOptionPane.showMessageDialog(view, "Please select a player to delete.",
+                        "Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            if (!view.confirmPlayerDeletion(name)) {
+                return;
+            }
+            try {
+                gameManager.deletePlayerByName(name);
+                SaveLoadService.saveGame(gameManager.getGameData());
+                JOptionPane.showMessageDialog(view, "Player \"" + name + "\" deleted.",
+                        "Success", JOptionPane.INFORMATION_MESSAGE);
+                refresh();
+            } catch (GameException ex) {
+                JOptionPane.showMessageDialog(view,
+                        "Could not delete player: " + ex.getMessage(),
+                        "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -23,6 +23,8 @@ import view.NewPlayersRegistrationView;
 import view.PlayerCharacterManagementView;
 import view.PlayerRegistrationView;
 import view.SavedPlayersRegistrationView;
+import view.PlayerDeleteView;
+import controller.PlayerDeleteController;
 
 public final class SceneManager {
 
@@ -40,6 +42,7 @@ public final class SceneManager {
     private static final String CARD_CHARACTER_MENU = "characterMenu";
     private static final String CARD_PLAYER_CHARACTER = "playerCharacter";
     private static final String CARD_BATTLE = "battle";
+    private static final String CARD_DELETE_PLAYER = "deletePlayer";
 
     // ---------- Cached View Instances ----------
     private MainMenuView mainMenuView;
@@ -50,6 +53,8 @@ public final class SceneManager {
     private CharacterManagementMenuView characterMenuView;
     private PlayerCharacterManagementView playerCharacterView;
     private BattleView battleView;
+    private PlayerDeleteView playerDeleteView;
+    private PlayerDeleteController playerDeleteController;
 
     private GameManagerController gameManagerController; // Keep the controller instance here
     private HallOfFameController hallOfFameController;
@@ -94,6 +99,7 @@ public final class SceneManager {
                 switch (cmd) {
                     case PlayerRegistrationView.NEW_PLAYERS -> showNewPlayersRegistration();
                     case PlayerRegistrationView.SAVED_PLAYERS -> showSavedPlayersRegistration();
+                    case PlayerRegistrationView.DELETE_PLAYER -> showPlayerDelete();
                     case PlayerRegistrationView.RETURN_TO_MENU -> showMainMenu();
                 }
             });
@@ -170,6 +176,18 @@ public final class SceneManager {
                     "Error", JOptionPane.ERROR_MESSAGE);
         }
         cards.show(root, CARD_SAVED_PLAYER_REG);
+    }
+
+    /** Shows the delete player screen. */
+    public void showPlayerDelete() {
+        if (playerDeleteView == null) {
+            playerDeleteView = new PlayerDeleteView();
+            playerDeleteController = new PlayerDeleteController(playerDeleteView, gameManagerController);
+            root.add(playerDeleteView, CARD_DELETE_PLAYER);
+        } else {
+            playerDeleteController.refresh();
+        }
+        cards.show(root, CARD_DELETE_PLAYER);
     }
 
     /** Displays the Hall of Fame screen. */


### PR DESCRIPTION
## Summary
- implement PlayerDeleteController for player removal
- expose deletePlayerByName and getGameData in GameManagerController
- add delete-player scene and route in SceneManager
- hook delete player option in PlayerRegistrationView

## Testing
- `mvn test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68849052a67883288c1291528eb849dc