### PR TITLE
Fix player delete return navigation

### DIFF
--- a/controller/PlayerDeleteController.java
+++ b/controller/PlayerDeleteController.java
@@ -18,10 +18,12 @@ public class PlayerDeleteController implements ActionListener {
 
     private final PlayerDeleteView view;
     private final GameManagerController gameManager;
+    private final SceneManager sceneManager;
 
-    public PlayerDeleteController(PlayerDeleteView view, GameManagerController gameManager) {
+    public PlayerDeleteController(PlayerDeleteView view, GameManagerController gameManager, SceneManager sceneManager) {
         this.view = view;
         this.gameManager = gameManager;
+        this.sceneManager = sceneManager;
         this.view.setActionListener(this);
         refresh();
     }
@@ -44,7 +46,7 @@ public class PlayerDeleteController implements ActionListener {
         String cmd = e.getActionCommand();
         if (PlayerDeleteView.RETURN.equals(cmd)) {
             view.dispose();
-            gameManager.navigateBackToMainMenu();
+            sceneManager.showPlayerRegistration();
         } else if (PlayerDeleteView.DELETE.equals(cmd)) {
             String name = view.getSelectedPlayer();
             if (name == null) {

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -184,7 +184,7 @@ public final class SceneManager {
     public void showPlayerDelete() {
         if (playerDeleteView == null) {
             playerDeleteView = new PlayerDeleteView();
-            playerDeleteController = new PlayerDeleteController(playerDeleteView, gameManagerController);
+            playerDeleteController = new PlayerDeleteController(playerDeleteView, gameManagerController, this);
             root.add(playerDeleteView.getContentPane(), CARD_DELETE_PLAYER);
         } else {
             playerDeleteController.refresh();

--- a/view/PlayerDeleteView.java
+++ b/view/PlayerDeleteView.java
@@ -51,7 +51,7 @@ public class PlayerDeleteView extends JFrame {
 
         setLocationRelativeTo(null);
         setResizable(false);
-        setVisible(true);
+        // Visibility is controlled by SceneManager
     }
 
 

--- a/view/PlayerRegistrationView.java
+++ b/view/PlayerRegistrationView.java
@@ -64,7 +64,7 @@ public class PlayerRegistrationView extends JFrame {
 
         setLocationRelativeTo(null);
         setResizable(false);
-        setVisible(true);
+        // Visibility is controlled by SceneManager
     }
 
 


### PR DESCRIPTION
## Summary
- delegate view visibility to SceneManager
- adjust PlayerDeleteController to navigate back to player registration
- pass SceneManager to PlayerDeleteController

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*
- `javac $(find . -name '*.java')` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68849b18f464832899eafa08f322e446