### PR TITLE
Improve character management navigation

### DIFF
--- a/controller/CharacterManagementMenuController.java
+++ b/controller/CharacterManagementMenuController.java
@@ -2,6 +2,7 @@ package controller;
 
 import model.core.Player;
 import view.CharacterManagementMenuView;
+import javax.swing.JOptionPane;
 
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -19,6 +20,7 @@ public class CharacterManagementMenuController {
         this.players = players;
         this.sceneManager = sceneManager;
         bind();
+        updateLabels();
     }
 
     private void bind() {
@@ -37,6 +39,25 @@ public class CharacterManagementMenuController {
         if (idx >= 0 && idx < players.size()) {
             Player p = players.get(idx);
             sceneManager.showPlayerCharacterManagement(p);
+        }
+    }
+
+    private void updateLabels() {
+        if (players.isEmpty()) {
+            JOptionPane.showMessageDialog(view,
+                    "No players registered.",
+                    "Info", JOptionPane.INFORMATION_MESSAGE);
+            view.setPlayer1Name(null);
+            view.setPlayer2Name(null);
+            return;
+        }
+        if (players.size() > 0) {
+            view.setPlayer1Name(players.get(0).getName());
+        }
+        if (players.size() > 1) {
+            view.setPlayer2Name(players.get(1).getName());
+        } else {
+            view.setPlayer2Name(null);
         }
     }
 }

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -60,6 +60,7 @@ public class PlayerCharacterManagementController {
             }
         });
         refreshCharacterList(listView);
+        listView.setVisible(true);
     }
 
     private void refreshCharacterList(CharacterListViewingView lv) {
@@ -116,6 +117,7 @@ public class PlayerCharacterManagementController {
             }
         });
         specView.resetView();
+        specView.setVisible(true);
     }
 
     private void openEditCharacter() {
@@ -136,6 +138,7 @@ public class PlayerCharacterManagementController {
         });
 
         populateEditFields(editView);
+        editView.setVisible(true);
     }
 
     private void populateEditFields(CharacterEditView ev) {

--- a/view/CharacterManagementMenuView.java
+++ b/view/CharacterManagementMenuView.java
@@ -65,6 +65,32 @@ public class CharacterManagementMenuView extends JFrame {
         setContentPane(bgPanel);
     }
 
+    /**
+     * Updates the label for the first player's manage button.
+     */
+    public void setPlayer1Name(String name) {
+        if (name == null || name.isBlank()) {
+            btnManagePlayer1.setText(MANAGE_PLAYER1);
+            btnManagePlayer1.setEnabled(false);
+        } else {
+            btnManagePlayer1.setText("Manage " + name);
+            btnManagePlayer1.setEnabled(true);
+        }
+    }
+
+    /**
+     * Updates the label for the second player's manage button.
+     */
+    public void setPlayer2Name(String name) {
+        if (name == null || name.isBlank()) {
+            btnManagePlayer2.setText(MANAGE_PLAYER2);
+            btnManagePlayer2.setEnabled(false);
+        } else {
+            btnManagePlayer2.setText("Manage " + name);
+            btnManagePlayer2.setEnabled(true);
+        }
+    }
+
     public void setActionListener(ActionListener l) {
         btnManagePlayer1.addActionListener(l);
         btnManagePlayer2.addActionListener(l);


### PR DESCRIPTION
## Summary
- update CharacterManagementMenuView with player name setters
- show info when no players are registered and label buttons accordingly
- ensure character sub-views become visible from controller

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884a17c694c8328a017bb26718cafab