### PR TITLE
Fix character management views and UI issues

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -167,7 +167,12 @@ public void actionPerformed(ActionEvent e) {
                         view.dispose();
                     }
                     case CharacterCreationManagementView.RETURN -> {
-                        navigateBackToMainMenu();
+                        Player player = findByName(players, playerName);
+                        if (player != null) {
+                            handleNavigateToCharacterManagement(player);
+                        } else {
+                            navigateBackToMainMenu();
+                        }
                         view.dispose();
                     }
                 }

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -98,8 +98,16 @@ public class PlayerCharacterManagementController {
 
     private void openCharacterSpecView() {
         CharacterSpecViewingView specView = new CharacterSpecViewingView(view.getPlayerID());
-        specView.setCharacterOptions(player.getCharacters().stream()
-                .map(Character::getName).toArray(String[]::new));
+        specView.resetView();
+        java.util.List<Character> chars = player.getCharacters();
+        String[] names = chars.stream().map(Character::getName).toArray(String[]::new);
+        specView.setCharacterOptions(names);
+        if (names.length == 0) {
+            specView.updateCharacterDetails("No characters available.");
+            specView.setCharacterSelectionEnabled(false);
+        } else {
+            specView.setCharacterSelectionEnabled(true);
+        }
         specView.setActionListener(e -> {
             String cmd = e.getActionCommand();
             if (CharacterSpecViewingView.RETURN.equals(cmd)) {
@@ -116,7 +124,6 @@ public class PlayerCharacterManagementController {
                 specView.updateCharacterDetails(details);
             }
         });
-        specView.resetView();
         specView.setVisible(true);
     }
 

--- a/view/CharacterManualCreationView.java
+++ b/view/CharacterManualCreationView.java
@@ -139,14 +139,16 @@ public class CharacterManualCreationView extends JFrame {
         panel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         OutlinedLabel label = new OutlinedLabel(labelText);
-        int fixedLabelWidth = 140;
+        int fixedLabelWidth = 170; // widened to prevent cutoff of text
         Dimension labelSize = new Dimension(fixedLabelWidth, label.getPreferredSize().height);
         label.setPreferredSize(labelSize);
         label.setMinimumSize(labelSize);
         label.setMaximumSize(labelSize);
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
-        dropdown.setMaximumSize(new Dimension(250, 35));
+        Dimension ddSize = new Dimension(280, 35);
+        dropdown.setPreferredSize(ddSize);
+        dropdown.setMaximumSize(ddSize);
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 
         panel.add(label);

--- a/view/CharacterSpecViewingView.java
+++ b/view/CharacterSpecViewingView.java
@@ -199,6 +199,15 @@ public class CharacterSpecViewingView extends JFrame {
         }
     }
 
+    /**
+     * Enables or disables the dropdown used for character selection.
+     *
+     * @param enabled true to enable selection, false to disable
+     */
+    public void setCharacterSelectionEnabled(boolean enabled) {
+        charDropdown.setEnabled(enabled);
+    }
+
 
     public String getSelectedCharacter() {
         return (String) charDropdown.getSelectedItem();


### PR DESCRIPTION
## Summary
- refresh character selection in `CharacterSpecViewingView`
- disable dropdown when no characters are available
- return from creation menu to player management
- enlarge ability labels and dropdowns in manual creation view

## Testing
- `javac $(find app controller model view -name '*.java')`
- `mvn -q test` *(fails: Could not resolve plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884ad3bfdc883288670486cfc09017e