### PR TITLE
Fix ability 4 dropdown filtering

### DIFF
--- a/controller/CharacterManualCreationController.java
+++ b/controller/CharacterManualCreationController.java
@@ -194,9 +194,7 @@ public final class CharacterManualCreationController {
 
             String raceStr = view.getSelectedRace();
             if (raceStr != null && !raceStr.isBlank() && RaceType.valueOf(raceStr) == RaceType.GNOME) {
-                List<String> allAbilityNames = classService.getAllAbilities().stream()
-                        .map(Ability::getName).toList();
-                view.setAbilityOptions(4, allAbilityNames.toArray(new String[0]));
+                view.setAbilityOptions(4, options);
             }
         } catch (Exception e) {
             clearAbilityOptions();

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -173,9 +173,7 @@ public class PlayerCharacterManagementController {
         boolean isGnome = c.getRaceType() == model.core.RaceType.GNOME;
         ev.setAbility4Visible(isGnome);
         if (isGnome) {
-            String[] all = classService.getAllAbilities().stream()
-                    .map(Ability::getName).toArray(String[]::new);
-            ev.setAbilityOptions(4, all);
+            ev.setAbilityOptions(4, opts);
         }
 
         List<Ability> current = c.getAbilities();


### PR DESCRIPTION
## Summary
- show only class abilities in ability slot 4
- adjust edit screen to match creation screen

## Testing
- `mvn -q test` *(fails: Plugin resolution, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6884c96c68a08328aafdb346eddcc92f