### PR TITLE
Add battle mode selection and PvP setup

### DIFF
--- a/controller/BattleCharSelectionController.java
+++ b/controller/BattleCharSelectionController.java
@@ -1,0 +1,81 @@
+package controller;
+
+import view.BattleCharSelectionView;
+import model.core.Player;
+import model.core.Character;
+import model.core.Ability;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/** Controller for selecting a character for battle. */
+public class BattleCharSelectionController implements ActionListener {
+    private final BattleCharSelectionView view;
+    private final Player player;
+    private final Consumer<Character> onSelect;
+    private final Runnable onReturn;
+
+    public BattleCharSelectionController(BattleCharSelectionView view,
+                                         Player player,
+                                         Consumer<Character> onSelect,
+                                         Runnable onReturn) {
+        this.view = view;
+        this.player = player;
+        this.onSelect = onSelect;
+        this.onReturn = onReturn;
+        this.view.setActionListener(this);
+        refresh();
+    }
+
+    private void refresh() {
+        List<Character> chars = player.getCharacters();
+        String[] options = chars.stream().map(Character::getName).toArray(String[]::new);
+        view.setCharacterOptions(options);
+        String details;
+        if (chars.isEmpty()) {
+            details = "No characters available.";
+        } else {
+            details = chars.stream()
+                    .map(c -> c.toString() + "\nAbilities: " +
+                            c.getAbilities().stream().map(Ability::getName)
+                             .collect(Collectors.joining(", ")))
+                    .collect(Collectors.joining("\n\n"));
+        }
+        view.updateCharacterList(details);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String cmd = e.getActionCommand();
+        if (BattleCharSelectionView.SELECT.equals(cmd)) {
+            handleSelect();
+        } else if (BattleCharSelectionView.RETURN.equals(cmd)) {
+            view.dispose();
+            if (onReturn != null) onReturn.run();
+        }
+    }
+
+    private void handleSelect() {
+        String name = view.getSelectedCharacter();
+        if (name == null) {
+            JOptionPane.showMessageDialog(view, "No character selected.",
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        if (!view.confirmCharacterSelection(name)) {
+            return;
+        }
+        Character c = player.getCharacter(name).orElse(null);
+        if (c == null) {
+            JOptionPane.showMessageDialog(view, "Character not found.",
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        view.dispose();
+        if (onSelect != null) onSelect.accept(c);
+    }
+}

--- a/controller/BattleModesController.java
+++ b/controller/BattleModesController.java
@@ -1,0 +1,64 @@
+package controller;
+
+import view.BattleModesView;
+import model.core.Player;
+import controller.GameManagerController;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+/** Controller for selecting battle mode (PvP or PvB). */
+public class BattleModesController implements ActionListener {
+    private final BattleModesView view;
+    private final List<Player> players;
+    private final SceneManager sceneManager;
+    private final GameManagerController gameManagerController;
+
+    public BattleModesController(BattleModesView view,
+                                 List<Player> players,
+                                 SceneManager sceneManager,
+                                 GameManagerController gm) {
+        this.view = view;
+        this.players = players;
+        this.sceneManager = sceneManager;
+        this.gameManagerController = gm;
+        this.view.setActionListener(this);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String cmd = e.getActionCommand();
+        switch (cmd) {
+            case BattleModesView.PLAYER_VS_PLAYER -> handlePvP();
+            case BattleModesView.PLAYER_VS_BOT -> handlePvB();
+            case BattleModesView.RETURN -> {
+                view.dispose();
+                gameManagerController.navigateBackToMainMenu();
+            }
+        }
+    }
+
+    private void handlePvP() {
+        if (players.size() < 2) {
+            JOptionPane.showMessageDialog(view, "Two players required for PvP.",
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        view.dispose();
+        new BattleSetupController(sceneManager, players)
+                .startPvP();
+    }
+
+    private void handlePvB() {
+        if (players.isEmpty()) {
+            JOptionPane.showMessageDialog(view, "No players registered.",
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        view.dispose();
+        new BattleSetupController(sceneManager, players)
+                .startPvB();
+    }
+}

--- a/controller/BattleSetupController.java
+++ b/controller/BattleSetupController.java
@@ -1,0 +1,76 @@
+package controller;
+
+import model.core.Character;
+import model.core.Player;
+import model.util.DialogUtils;
+import model.util.GameException;
+import model.util.RandomCharacterGenerator;
+import model.util.SimpleBot;
+import view.BattleCharSelectionView;
+
+import java.util.List;
+import java.util.Random;
+
+/** Orchestrates character selection and launches battles. */
+public class BattleSetupController {
+    private final SceneManager sceneManager;
+    private final List<Player> players;
+
+    private Character p1Char;
+    private Character p2Char;
+
+    public BattleSetupController(SceneManager sceneManager,
+                                 List<Player> players) {
+        this.sceneManager = sceneManager;
+        this.players = players;
+    }
+
+    public void startPvP() {
+        selectPlayer1ForPvP();
+    }
+
+    public void startPvB() {
+        selectPlayerForPvB();
+    }
+
+    private void selectPlayer1ForPvP() {
+        BattleCharSelectionView view = new BattleCharSelectionView(1);
+        view.setVisible(true);
+        new BattleCharSelectionController(view, players.get(0), c -> {
+            p1Char = c;
+            selectPlayer2ForPvP();
+        }, () -> sceneManager.showBattleModes(players));
+    }
+
+    private void selectPlayer2ForPvP() {
+        BattleCharSelectionView view = new BattleCharSelectionView(2);
+        view.setVisible(true);
+        new BattleCharSelectionController(view, players.get(1), c -> {
+            p2Char = c;
+            launchPvP();
+        }, () -> sceneManager.showBattleModes(players));
+    }
+
+    private void selectPlayerForPvB() {
+        BattleCharSelectionView view = new BattleCharSelectionView(1);
+        view.setVisible(true);
+        new BattleCharSelectionController(view, players.get(0), c -> {
+            p1Char = c;
+            launchPvB();
+        }, () -> sceneManager.showBattleModes(players));
+    }
+
+    private void launchPvP() {
+        sceneManager.showPlayerVsPlayerBattle(players.get(0), p1Char, players.get(1), p2Char);
+    }
+
+    private void launchPvB() {
+        try {
+            Character bot = RandomCharacterGenerator.generate("Bot");
+            AIController ai = new AIController(new SimpleBot(new Random()));
+            sceneManager.showPlayerVsBotBattle(players.get(0), p1Char, bot, ai);
+        } catch (GameException e) {
+            DialogUtils.showErrorDialog("Battle Error", e.getMessage());
+        }
+    }
+}

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -19,8 +19,6 @@ import model.service.MagicItemFactory;
 import model.util.Constants;
 import model.util.GameException;
 import model.util.InputValidator;
-import model.util.RandomCharacterGenerator;
-import model.util.SimpleBot;
 import persistence.GameData;
 import persistence.SaveLoadService;
 import view.CharacterAutoCreationView;
@@ -119,19 +117,11 @@ public void actionPerformed(ActionEvent e) {
             mainMenuView.dispose(); // Close the MainMenuView
         }
         case MainMenuView.ACTION_START_BATTLE -> {
-            if (players.isEmpty() || players.get(0).getCharacters().isEmpty()) {
-                JOptionPane.showMessageDialog(mainMenuView, "Please create a player and at least one character first.", "Error", JOptionPane.ERROR_MESSAGE);
+            if (players.isEmpty()) {
+                JOptionPane.showMessageDialog(mainMenuView, "Please register players first.", "Error", JOptionPane.ERROR_MESSAGE);
             } else {
-                Player player = players.get(0);
-                Character human = player.getCharacters().get(0);
-                try {
-                    Character bot = RandomCharacterGenerator.generate("Bot");
-                    AIController ai = new AIController(new SimpleBot(new java.util.Random()));
-                    sceneManager.showPlayerVsBotBattle(player, human, bot, ai);
-                    mainMenuView.dispose();
-                } catch (GameException e1) {
-                    JOptionPane.showMessageDialog(mainMenuView, "Failed to start battle: " + e1.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-                }
+                sceneManager.showBattleModes(players);
+                mainMenuView.dispose();
             }
         }
         case MainMenuView.ACTION_EXIT -> {

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -676,8 +676,18 @@ public class BattleView extends JFrame {
         return cmbP1Abilities;
     }
 
+    public JComboBox<String> getAbilitySelectorP2() {
+        return cmbP2Abilities;
+    }
+
     public void addUseAbilityP1Listener(ActionListener l) {
         btnP1Use.addActionListener(l);
+    }
+
+    public void addUseAbilityP2Listener(ActionListener l) {
+        if (btnP2Use != null) {
+            btnP2Use.addActionListener(l);
+        }
     }
 
     public void addReturnListener(ActionListener l) {


### PR DESCRIPTION
## Summary
- create controllers for battle mode flow
- add PvP battle launch logic
- extend battle view with player 2 helpers
- connect new screens via SceneManager and GameManagerController

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6884cc9f76bc8328984fd87c7ce6ae6a