### PR TITLE
Fix battle view launch after character selection

### DIFF
--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -275,6 +275,8 @@ public final class SceneManager {
                 battleView.dispose();
                 showMainMenu();
             });
+            root.add(battleView.getContentPane(), CARD_BATTLE);
+            cards.show(root, CARD_BATTLE);
             battleController.startBattleVsBot(human, bot, aiController);
         } catch (GameException e) {
             JOptionPane.showMessageDialog(stage, "Unable to start battle: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
@@ -312,6 +314,8 @@ public final class SceneManager {
                 battleView.dispose();
                 showMainMenu();
             });
+            root.add(battleView.getContentPane(), CARD_BATTLE);
+            cards.show(root, CARD_BATTLE);
             controller.startBattle(c1, c2);
         } catch (GameException e) {
             JOptionPane.showMessageDialog(stage, "Unable to start battle: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
## Summary
- ensure PvP and PvB battle views are shown after selecting characters

## Testing
- `mvn -q test` *(fails: maven plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6884d3c861ec8328ba69f3a633dd5df8