### PR TITLE
Fix BattleView layout

### DIFF
--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -193,6 +193,7 @@ public class BattleView extends JFrame {
         battleOutcomeArea.setEditable(false);
         battleOutcomeArea.setLineWrap(true);
         battleOutcomeArea.setWrapStyleWord(true);
+        battleOutcomePanel.add(battleOutcomeArea, BorderLayout.CENTER);
 
         centerPanel.add(battleLogPanel);
         centerPanel.add(Box.createVerticalStrut(30));
@@ -492,24 +493,21 @@ public class BattleView extends JFrame {
     private JPanel createDropdownPanel(String labelText, JComboBox<String> dropdown) {
         JPanel panel = new JPanel();
         panel.setOpaque(false);
-        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         OutlinedLabel label = new OutlinedLabel(labelText);
-        Dimension labelSize = new Dimension(200, label.getPreferredSize().height);
-        label.setPreferredSize(labelSize);
-        label.setMinimumSize(labelSize);
-        label.setMaximumSize(labelSize);
-        label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
+        label.setAlignmentX(Component.CENTER_ALIGNMENT);
+        label.setFont(new Font("Serif", Font.BOLD, 17));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
-        Dimension ddSize = new Dimension(350, 40);
-        dropdown.setPreferredSize(ddSize);
-        dropdown.setMaximumSize(ddSize);
-        dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
+        dropdown.setMaximumSize(new Dimension(250, 35));
+        dropdown.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         panel.add(label);
+        panel.add(Box.createVerticalStrut(5));
         panel.add(dropdown);
+
         return panel;
     }
 


### PR DESCRIPTION
## Summary
- update battle outcome panel to display text
- rewrite dropdown creation helper to match desired vertical layout

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `javac $(find .. -name '*.java')` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6884e6d261348328a594cffc0137d1a4