### PR TITLE
Ensure model collections always initialized

### DIFF
--- a/model/battle/CombatLog.java
+++ b/model/battle/CombatLog.java
@@ -16,8 +16,8 @@ import model.util.InputValidator;
  */
 public final class CombatLog {
 
-    /** Internal backing list; never exposed directly. */
-    private final List<String> logEntries = new ArrayList<>();
+    /** Internal backing list; always initialised. Never null. */
+    private List<String> logEntries = new ArrayList<>();
 
     /** Creates an empty log. */
     public CombatLog() { /* nothing to initialise */ }
@@ -48,5 +48,16 @@ public final class CombatLog {
      */
     public synchronized void clearLog() {
         logEntries.clear();
+    }
+
+    /**
+     * Ensures log entries list is initialised when deserialised.
+     */
+    private void readObject(java.io.ObjectInputStream in)
+            throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (logEntries == null) {
+            logEntries = new ArrayList<>();
+        }
     }
 }

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -32,9 +32,12 @@ public class Character implements Serializable {
     private final ClassType classType;
 
     // --- Core Mutable Attributes ---
-    private final List<Ability> abilities;
-    private final Inventory inventory;
-    private final transient List<StatusEffect> activeStatusEffects;
+    /** Character abilities. Always initialized. Never null. */
+    private final List<Ability> abilities = new ArrayList<>();
+    /** Inventory for magic items. Always initialized. Never null. */
+    private final Inventory inventory = new Inventory();
+    /** Status effects currently affecting the character. Always initialized. Never null. */
+    private transient List<StatusEffect> activeStatusEffects = new ArrayList<>();
     private MagicItem equippedItem;
 
     // --- Dynamic Stats ---
@@ -79,9 +82,11 @@ public class Character implements Serializable {
         this.name = name;
         this.race = race;
         this.classType = classType;
-        this.abilities = new ArrayList<>(abilities); // Defensive copy
-        this.inventory = new Inventory();
-        this.activeStatusEffects = new ArrayList<>();
+
+        this.abilities.clear();
+        this.abilities.addAll(abilities); // Defensive copy
+
+        this.activeStatusEffects.clear();
         this.equippedItem = null;
         this.isStunned = false;
 
@@ -332,5 +337,17 @@ public class Character implements Serializable {
             descriptions.append(ability.getDescription()).append("\n"); // Assuming Ability has a getDescription method
         }
         return descriptions.toString();
+    }
+
+    /**
+     * Ensures transient collections are properly initialised when this object
+     * is deserialised from a save file.
+     */
+    private void readObject(java.io.ObjectInputStream in)
+            throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (activeStatusEffects == null) {
+            activeStatusEffects = new ArrayList<>();
+        }
     }
 }

--- a/model/core/Player.java
+++ b/model/core/Player.java
@@ -15,13 +15,13 @@ public final class Player implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private final String name;
-    private final List<Character> characters;
+    /** Collection of the player's characters. Always initialized. Never null. */
+    private List<Character> characters = new ArrayList<>();
     private int cumulativeWins;
 
     public Player(String name) throws GameException {
         InputValidator.requireNonBlank(name, "Player name");
         this.name = name;
-        this.characters = new ArrayList<>();
         this.cumulativeWins = 0;
     }
 
@@ -65,5 +65,16 @@ public final class Player implements Serializable {
     public String toString() {
         return String.format("Player [name=%s, characters=%d, wins=%d]",
             name, characters.size(), cumulativeWins);
+    }
+
+    /**
+     * Ensures the characters list is initialised after deserialization.
+     */
+    private void readObject(java.io.ObjectInputStream in)
+            throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (characters == null) {
+            characters = new ArrayList<>();
+        }
     }
 }

--- a/model/item/Inventory.java
+++ b/model/item/Inventory.java
@@ -27,8 +27,8 @@ public final class Inventory implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    /** A unified list of all magic items the character possesses. */
-    private final List<MagicItem> items;
+    /** A unified list of all magic items the character possesses. Always initialized. Never null. */
+    private List<MagicItem> items = new ArrayList<>();
 
     /** A reference to the currently equipped magic item, which must also be in the items list. */
     private MagicItem equippedItem;
@@ -37,7 +37,6 @@ public final class Inventory implements Serializable {
      * Constructs an empty inventory.
      */
     public Inventory() {
-        this.items = new ArrayList<>();
         this.equippedItem = null;
     }
 
@@ -118,4 +117,15 @@ public final class Inventory implements Serializable {
     // The controller or battle system should process the effect externally
 }
 
-}
+    /**
+     * Ensures the items list is not null when deserialised.
+     */
+    private void readObject(java.io.ObjectInputStream in)
+            throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+    }
+
+} 


### PR DESCRIPTION
## Summary
- initialize collection fields on declaration for Character, Player, Inventory, and CombatLog
- add deserialization guards to keep collections from ever being null
- update constructors accordingly

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6884fe878f488328a6f793235ec5b1ad