### PR TITLE
Improve battle logging and fix Hall of Fame mutation

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -225,15 +225,19 @@ public final class BattleController {
             if (!t.actor.isAlive()) continue;
 
             if (t.actor.isStunned()) {
-                log.addEntry(t.actor.getName() + " is stunned and cannot act.");
+                log.addEntry(t.actor.getName() + " is stunned and skips their turn!");
             } else if (t.target.isAlive()) {
                 t.move.execute(t.actor, t.target, log);
+                if (!t.target.isAlive()) {
+                    log.addEntry(t.target.getName() + " has fallen!");
+                }
             }
 
             t.actor.processEndOfTurnEffects(log);
             if (battleEnded()) break;
         }
 
+        log.addEntry("--- End of Round " + battle.getRoundNumber() + " ---");
         view.displayTurnResults(log);
         updatePlayerPanels();
         selections.clear(); // prepare for next round
@@ -304,7 +308,8 @@ public final class BattleController {
     private void startRound() throws GameException {
         ensureRunning();
         CombatLog log = battle.getCombatLog();
-        log.addEntry("--- Round " + battle.getRoundNumber() + " Begins ---");
+        log.addEntry("--- Round " + battle.getRoundNumber() + " ---");
+        view.setRoundNumber(battle.getRoundNumber());
 
         processRoundStartFor(battle.getCharacter1(), log);
         processRoundStartFor(battle.getCharacter2(), log);
@@ -315,10 +320,14 @@ public final class BattleController {
 
     private void processRoundStartFor(Character c, CombatLog log) throws GameException {
         c.gainEp(Constants.ROUND_EP_REGEN);
+        log.addEntry(c.getName() + " regenerates " + Constants.ROUND_EP_REGEN + " EP.");
         if (c.getInventory().getEquippedItem() instanceof PassiveItem p) {
             applyPassiveItemEffect(c, p, log);
         }
         c.processStartOfTurnEffects(log);
+        if (!c.isAlive()) {
+            log.addEntry(c.getName() + " has fallen!");
+        }
     }
 
     private void applyPassiveItemEffect(Character c, PassiveItem item, CombatLog log) throws GameException {

--- a/model/battle/Battle.java
+++ b/model/battle/Battle.java
@@ -117,7 +117,6 @@ public final class Battle {
             throw new GameException("Cannot advance rounds on a finished battle.");
         }
         roundNumber++;
-        combatLog.addEntry("── Round " + roundNumber + " ──");
     }
 
     /**

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -289,7 +289,14 @@ public class Character implements Serializable {
         var iterator = activeStatusEffects.iterator();
         while (iterator.hasNext()) {
             StatusEffect effect = iterator.next();
+            int beforeHp = this.currentHp;
             effect.onTurnStart(this);
+            if (effect.getType() == StatusEffectType.POISONED) {
+                int dmg = beforeHp - this.currentHp;
+                if (dmg > 0) {
+                    log.addEntry(this.name + " suffers " + dmg + " poison damage.");
+                }
+            }
             if (effect.getDuration() <= 0) {
                 effect.remove(this);
                 iterator.remove();

--- a/model/util/effects/StunEffect.java
+++ b/model/util/effects/StunEffect.java
@@ -29,13 +29,13 @@ import model.util.StatusEffectType;
 public final class StunEffect implements StatusEffect {
 
     /** Default number of turns stun lasts. */
-    private static final int DURATION_TURNS = 2;
+    private static final int DURATION_TURNS = 1;
 
     /** Remaining turns for which the target is stunned. */
     private int remainingTurns;
 
     /**
-     * Constructs a new {@code StunEffect} with 2-turn duration.
+     * Constructs a new {@code StunEffect} with 1-turn duration.
      */
     public StunEffect() {
         this.remainingTurns = DURATION_TURNS;

--- a/persistence/SaveLoadService.java
+++ b/persistence/SaveLoadService.java
@@ -54,17 +54,20 @@ public class SaveLoadService {
     public static List<HallOfFameEntry> loadHallOfFame() throws GameException {
         try (ObjectInputStream hallOfFameStream = new ObjectInputStream(new FileInputStream(HALL_OF_FAME_FILE))) {
             Object obj = hallOfFameStream.readObject();
-            if (obj instanceof List<?>) {
-                List<?> rawList = (List<?>) obj;
-                // Ensure the list contains the right type
-                return (List<HallOfFameEntry>) rawList;
+            if (obj instanceof List<?> rawList) {
+                // Defensive copy into mutable list
+                List<HallOfFameEntry> entries = new ArrayList<>();
+                for (Object o : rawList) {
+                    entries.add((HallOfFameEntry) o);
+                }
+                return entries;
             } else {
                 throw new GameException("Invalid Hall of Fame data.");
             }
         } catch (FileNotFoundException e) {
             // If no Hall of Fame data is found, return an empty list
             System.out.println("No Hall of Fame found. Returning empty Hall of Fame.");
-            return List.of(); // Returning an empty list
+            return new ArrayList<>();
         } catch (IOException | ClassNotFoundException e) {
             // Handle any I/O errors or deserialization issues
             throw new GameException("Failed to load Hall of Fame data", e);

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -27,6 +27,7 @@ import javax.swing.JTextArea;
 
 import model.battle.CombatLog;
 import model.core.Character;
+import view.OutlinedLabel;
 
 // import controller._;
 
@@ -56,6 +57,7 @@ public class BattleView extends JFrame {
     private JComboBox<String> cmbP0Abilities = new JComboBox<>();
     private JTextArea p1NameCharNameArea, p2NameCharNameArea, p0NameCharNameArea, botNameCharNameArea, p1StatusArea, p2StatusArea, p0StatusArea, botStatusArea;
     private JTextArea p1AbilitiesItemsArea, p2AbilitiesItemsArea, p0AbilitiesItemsArea, botAbilitiesItemsArea, battleLogArea, battleOutcomeArea;
+    private OutlinedLabel roundLabel;
     
     /**
      * Constructs the Battle UI of Fatal Fantasy: Tactics Game.
@@ -151,7 +153,12 @@ public class BattleView extends JFrame {
         centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
         bottomPanel.setOpaque(false);
 
-        centerPanel.add(Box.createVerticalStrut(100));
+        centerPanel.add(Box.createVerticalStrut(20));
+        roundLabel = new OutlinedLabel("Round 1");
+        roundLabel.setFont(new Font("Serif", Font.BOLD, 22));
+        roundLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        centerPanel.add(roundLabel);
+        centerPanel.add(Box.createVerticalStrut(60));
 
         // Rounded display box for battle log
         RoundedDisplayBox battleLogPanel = new RoundedDisplayBox();
@@ -651,6 +658,17 @@ public class BattleView extends JFrame {
      */
     public void setBattleOutcome(String text) {
         battleOutcomeArea.setText(text);
+    }
+
+    /**
+     * Updates the displayed round number.
+     *
+     * @param round current battle round
+     */
+    public void setRoundNumber(int round) {
+        if (roundLabel != null) {
+            roundLabel.setText("Round " + round);
+        }
     }
     
 


### PR DESCRIPTION
## Summary
- return mutable list from `loadHallOfFame`
- track round headers and regeneration in battle logs
- show round number on battle screen
- shorten stun duration to one turn
- log poison damage and death events

## Testing
- `mvn -q test` *(fails: Plugin resolution from repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688504a83fb48328bee00d8b9089f43c