### PR TITLE
Implement battle reset flow with rematch support

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -6,6 +6,7 @@ import model.battle.Move;
 import model.battle.Defend;
 import model.battle.Recharge;
 import model.battle.ItemMove;
+import model.battle.AbilityMove;
 import model.core.Character;
 import model.core.Ability;
 import model.core.Player;
@@ -48,6 +49,13 @@ public final class BattleController {
     private Battle battle; // null ⇢ idle
     private final Map<Character, Move> selections = new HashMap<>(2);
 
+    // Keep references to the persistent characters used to launch the battle
+    private Character originalC1;
+    private Character originalC2;
+    // Copies used during the active battle session
+    private Character battleC1;
+    private Character battleC2;
+
     // AI support
     private AIController aiController;
     private Character aiCharacter;
@@ -83,12 +91,22 @@ public final class BattleController {
             throw new GameException("Both characters must be alive to start a battle.");
         }
 
-        battle = new Battle(c1, c2);
+        // Preserve references to the persistent characters
+        originalC1 = c1;
+        originalC2 = c2;
+
+        // Create fresh copies for battle so HP/EP changes don't persist
+        battleC1 = c1.copyForBattle();
+        battleC2 = c2.copyForBattle();
+
+        battle = new Battle(battleC1, battleC2);
         selections.clear();
         aiController = null;
         aiCharacter = null;
         humanOpponent = null;
-        view.displayBattleStart(c1, c2);
+        view.displayBattleStart(battleC1, battleC2);
+        view.setBattleControlsEnabled(true);
+        view.setEndButtonsEnabled(false);
         updatePlayerPanels();
         startRound();
     }
@@ -104,8 +122,9 @@ public final class BattleController {
 
         startBattle(human, bot);
         this.aiController = ai;
-        this.aiCharacter = bot;
-        this.humanOpponent = human;
+        // battleC1/battleC2 now reference the copies created in startBattle
+        this.aiCharacter = battleC2;
+        this.humanOpponent = battleC1;
 
         queueAIMove(); // Bot selects its first move immediately
     }
@@ -249,20 +268,23 @@ public final class BattleController {
             Character loser = (winner == battle.getCharacter1())
                     ? battle.getCharacter2() : battle.getCharacter1();
 
+            Character persistentWinner = (winner == battleC1) ? originalC1 : originalC2;
+            Character persistentLoser  = (winner == battleC1) ? originalC2 : originalC1;
+
             // Award XP and handle win persistence if players are known
             if (gameManagerController != null) {
-                Player winPlayer = (winner == battle.getCharacter1()) ? player1 : player2;
+                Player winPlayer = (winner == battleC1) ? player1 : player2;
                 if (winPlayer != null) {
-                    int xp = LevelingSystem.calculateXpGained(winner, loser);
-                    winner.addXp(xp);
-                    log.addEntry(winner.getName() + " gains " + xp + " XP.");
-                    if (gameManagerController != null) {
-                        gameManagerController.handlePlayerWin(winPlayer, winner);
-                    }
+                    int xp = LevelingSystem.calculateXpGained(persistentWinner, persistentLoser);
+                    persistentWinner.addXp(xp);
+                    log.addEntry(persistentWinner.getName() + " gains " + xp + " XP.");
+                    gameManagerController.handlePlayerWin(winPlayer, persistentWinner);
                 }
             }
 
-            view.displayBattleEnd(winner);
+            view.displayBattleEnd(persistentWinner);
+            log.addEntry("Battle complete. Choose Rematch to play again or Return to main menu.");
+            view.displayTurnResults(log);
             updatePlayerPanels();
             battle = null; // back to idle state
             aiController = null;

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -276,6 +276,13 @@ public final class SceneManager {
                 battleView.dispose();
                 showMainMenu();
             });
+            battleView.addRematchListener(e -> {
+                try {
+                    battleController.startBattleVsBot(human, bot, aiController);
+                } catch (GameException ex) {
+                    DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                }
+            });
             root.add(battleView.getContentPane(), CARD_BATTLE);
             stage.setSize(1200, 700);
             cards.show(root, CARD_BATTLE);
@@ -315,6 +322,13 @@ public final class SceneManager {
             battleView.addReturnListener(e -> {
                 battleView.dispose();
                 showMainMenu();
+            });
+            battleView.addRematchListener(e -> {
+                try {
+                    controller.startBattle(c1, c2);
+                } catch (GameException ex) {
+                    DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                }
             });
             root.add(battleView.getContentPane(), CARD_BATTLE);
             stage.setSize(1200, 700);

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -213,6 +213,8 @@ public class BattleView extends JFrame {
 
         btnRematch = new RoundedButton(REMATCH);
         btnReturn = new RoundedButton(RETURN);
+        btnRematch.setEnabled(false);
+        btnReturn.setEnabled(false);
 
         buttonPanel.add(btnRematch);
         buttonPanel.add(btnReturn);
@@ -706,6 +708,10 @@ public class BattleView extends JFrame {
         }
     }
 
+    public void addRematchListener(ActionListener l) {
+        btnRematch.addActionListener(l);
+    }
+
     public void addReturnListener(ActionListener l) {
         btnReturn.addActionListener(l);
     }
@@ -715,6 +721,22 @@ public class BattleView extends JFrame {
         if (btnP2Use != null) {
             btnP2Use.setEnabled(enabled);
         }
+    }
+
+    /** Enables or disables all ability controls for both players. */
+    public void setBattleControlsEnabled(boolean enabled) {
+        cmbP1Abilities.setEnabled(enabled);
+        cmbP2Abilities.setEnabled(enabled);
+        cmbP0Abilities.setEnabled(enabled);
+        if (btnP1Use != null) btnP1Use.setEnabled(enabled);
+        if (btnP2Use != null) btnP2Use.setEnabled(enabled);
+        if (btnP0Use != null) btnP0Use.setEnabled(enabled);
+    }
+
+    /** Enables or disables the rematch and return buttons. */
+    public void setEndButtonsEnabled(boolean enabled) {
+        btnRematch.setEnabled(enabled);
+        btnReturn.setEnabled(enabled);
     }
 
     // --- Minimal callbacks expected by BattleController ---
@@ -731,6 +753,8 @@ public class BattleView extends JFrame {
 
     public void displayBattleEnd(Character winner) {
         setBattleOutcome(winner.getName() + " wins!");
+        setBattleControlsEnabled(false);
+        setEndButtonsEnabled(true);
     }
 
 }


### PR DESCRIPTION
## Summary
- add `Character.copyForBattle` to create clean battle instances
- use copied characters in `BattleController`
- award XP to persistent characters and log battle end message
- enable rematch and return buttons on battle conclusion
- wire up rematch actions in `SceneManager`

## Testing
- `javac @main_sources.txt`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6885112721d48328bee24bea7abec80d