### PR TITLE
Fix battle participant mismatch in new rounds

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -61,6 +61,23 @@ public final class BattleController {
     private Character aiCharacter;
     private Character humanOpponent;
 
+    /* -------------------------------------------------------- ACCESSORS */
+
+    /**
+     * Returns the battle copy corresponding to the provided persistent character.
+     *
+     * @param original the persistent character used to start the battle
+     * @return the active battle copy or {@code null} if the character is unknown
+     */
+    public Character getBattleCopy(Character original) {
+        if (original == originalC1) {
+            return battleC1;
+        } else if (original == originalC2) {
+            return battleC2;
+        }
+        return null;
+    }
+
     /* ===================================================== CONSTRUCTION */
 
     public BattleController(BattleView battleView) throws GameException {

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -266,9 +266,14 @@ public final class SceneManager {
                 String choice = (String) battleView.getAbilitySelectorP1().getSelectedItem();
                 if (choice != null) {
                     try {
-                        battleController.handlePlayerChoice(human, choice);
+                        Character user = battleController.getBattleCopy(human);
+                        if (user != null) {
+                            battleController.handlePlayerChoice(user, choice);
+                        }
                     } catch (GameException ex) {
                         DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                        battleView.setBattleControlsEnabled(false);
+                        battleView.setEndButtonsEnabled(true);
                     }
                 }
             });
@@ -303,9 +308,14 @@ public final class SceneManager {
                 String choice = (String) battleView.getAbilitySelectorP1().getSelectedItem();
                 if (choice != null) {
                     try {
-                        controller.handlePlayerChoice(c1, choice);
+                        Character user = controller.getBattleCopy(c1);
+                        if (user != null) {
+                            controller.handlePlayerChoice(user, choice);
+                        }
                     } catch (GameException ex) {
                         DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                        battleView.setBattleControlsEnabled(false);
+                        battleView.setEndButtonsEnabled(true);
                     }
                 }
             });
@@ -313,9 +323,14 @@ public final class SceneManager {
                 String choice = (String) battleView.getAbilitySelectorP2().getSelectedItem();
                 if (choice != null) {
                     try {
-                        controller.handlePlayerChoice(c2, choice);
+                        Character user = controller.getBattleCopy(c2);
+                        if (user != null) {
+                            controller.handlePlayerChoice(user, choice);
+                        }
                     } catch (GameException ex) {
                         DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                        battleView.setBattleControlsEnabled(false);
+                        battleView.setEndButtonsEnabled(true);
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- map player actions to the correct battle copy of each character
- disable ability buttons when a fatal battle error occurs

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6885184023208328909c7a482e6bc699