### PR TITLE
Add feedback while waiting for second PvP action

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -162,9 +162,12 @@ public final class BattleController {
         }
 
         selections.put(user, move);
-
         if (selections.size() == 2) { // both combatants have chosen
             executeTurn();
+        } else {
+            // Provide feedback that the game is waiting for the other player's move
+            battle.getCombatLog().addEntry("Awaiting the other player's action...");
+            view.displayTurnResults(battle.getCombatLog());
         }
     }
 
@@ -208,6 +211,7 @@ public final class BattleController {
             submitMove(user, new AbilityMove(a));
         } else {
             battle.getCombatLog().addEntry("Unknown action: " + choice);
+            view.displayTurnResults(battle.getCombatLog());
         }
     }
 


### PR DESCRIPTION
## Summary
- show message when one player submits a move but the other hasn't yet
- display log for invalid ability selections

## Testing
- `mvn -q -DskipTests=false test` *(fails: plugin resolution due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68851d1a90048328ae38269c77e13971