### PR TITLE
Implement magic items

### DIFF
--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -190,11 +190,7 @@ public class Character implements Serializable {
 
         int finalDamage = damage;
 
-        // Passive item mitigation
-        var eq = inventory.getEquippedItem();
-        if (eq != null && "Golden Dragon Scale".equals(eq.getName())) {
-            finalDamage = (int) Math.ceil(finalDamage * 0.9); // 10% reduction
-        }
+        // Passive item mitigation reserved for future items
 
         if (hasStatusEffect(StatusEffectType.IMMUNITY)) {
             finalDamage = 0;
@@ -217,6 +213,16 @@ public class Character implements Serializable {
     public void heal(int healingAmount) {
         if (healingAmount < 0) return;
         this.currentHp = Math.min(this.maxHp, this.currentHp + healingAmount);
+    }
+
+    /**
+     * Permanently increases max HP by the specified amount.
+     * Current HP is boosted by the same value.
+     */
+    public void increaseMaxHp(int amount) {
+        if (amount <= 0) return;
+        this.maxHp += amount;
+        this.currentHp += amount;
     }
 
     /**

--- a/model/item/SingleUseEffectType.java
+++ b/model/item/SingleUseEffectType.java
@@ -9,5 +9,7 @@ public enum SingleUseEffectType {
     /** Restores EP to the user. */
     RESTORE_EP,
     /** Revives the user from KO with a percentage of max HP. */
-    REVIVE
+    REVIVE,
+    /** Grants temporary immunity from all damage. */
+    GRANT_IMMUNITY
 }

--- a/model/item/SingleUseItem.java
+++ b/model/item/SingleUseItem.java
@@ -114,6 +114,13 @@ public final class SingleUseItem extends MagicItem {
                             + " with " + restore + " HP!");
                 }
             }
+            case GRANT_IMMUNITY -> {
+                user.addStatusEffect(
+                        model.util.StatusEffectFactory.create(
+                                model.util.StatusEffectType.IMMUNITY));
+                log.addEntry(user.getName() + " uses " + getName()
+                        + " and becomes immune to damage!");
+            }
             default -> throw new GameException("Unhandled single-use effect: "
                     + effectType);
         }

--- a/model/service/MagicItemFactory.java
+++ b/model/service/MagicItemFactory.java
@@ -30,29 +30,30 @@ public final class MagicItemFactory {
      * ----------------------------------------------------------- */
 
     private static final List<MagicItem> COMMON_ITEMS = List.of(
-        new SingleUseItem("Minor Healing Potion", "Restore 25 HP.", "Common",
-                SingleUseEffectType.HEAL_HP, 25),
-        new PassiveItem("Copper Ring", "Max EP +5.", "Common")
+        new SingleUseItem("Potion of Minor Healing", "Heals 40 HP.", "Common",
+                SingleUseEffectType.HEAL_HP, 40),
+        new SingleUseItem("Scroll of Minor Energy", "Restores 20 EP.", "Common",
+                SingleUseEffectType.RESTORE_EP, 20),
+        new SingleUseItem("Defender's Aegis", "Negates all damage for one turn.", "Common",
+                SingleUseEffectType.GRANT_IMMUNITY, 1)
     );
 
     private static final List<MagicItem> UNCOMMON_ITEMS = List.of(
-        new SingleUseItem("Elixir of Focus", "Restore 15 EP.", "Uncommon",
-                SingleUseEffectType.RESTORE_EP, 15),
-        new PassiveItem("Silver Amulet", "Max HP +15.", "Uncommon")
+        new PassiveItem("Amulet of Vitality", "Max HP +20 while equipped.", "Uncommon"),
+        new PassiveItem("Ring of Focus", "+2 EP each turn.", "Uncommon")
     );
 
     private static final List<MagicItem> RARE_ITEMS = List.of(
-        new SingleUseItem("Phoenix Tear", "Revive from KO with 50% HP.", "Rare",
-                SingleUseEffectType.REVIVE, 50),
-        new PassiveItem("Golden Dragon Scale", "Defense +10%.", "Rare")
+        new PassiveItem("Orb of Resilience", "Heal +5 HP each turn.", "Rare"),
+        new PassiveItem("Ancient Tome of Power", "+5 EP each turn.", "Rare")
     );
 
     /* -------------------------------------------------------------
      * Rarity Weighting (Cumulative Ranges)
      * ----------------------------------------------------------- */
 
-    private static final int COMMON_UPPER   = 69; // 0–69
-    private static final int UNCOMMON_UPPER = 94; // 70–94
+    private static final int COMMON_UPPER   = 59; // 0–59
+    private static final int UNCOMMON_UPPER = 94; // 60–94
     // 95–99 → Rare
 
     private static final SecureRandom RNG = new SecureRandom();

--- a/src/test/java/controller/RewardSystemTest.java
+++ b/src/test/java/controller/RewardSystemTest.java
@@ -1,0 +1,66 @@
+package controller;
+
+import model.core.ClassType;
+import model.core.Character;
+import model.core.Player;
+import model.core.RaceType;
+import model.util.Constants;
+import model.util.GameException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import persistence.GameData;
+import persistence.SaveLoadService;
+
+import javax.swing.JFrame;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RewardSystemTest {
+
+    @BeforeEach
+    @AfterEach
+    public void clean() {
+        new File(Constants.SAVE_FILE_PATH).delete();
+    }
+
+    private GameManagerController buildController() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        SceneManager sm = new SceneManager();
+        Field f = SceneManager.class.getDeclaredField("gameManagerController");
+        f.setAccessible(true);
+        GameManagerController controller = (GameManagerController) f.get(sm);
+
+        Field stageField = SceneManager.class.getDeclaredField("stage");
+        stageField.setAccessible(true);
+        JFrame stage = (JFrame) stageField.get(sm);
+        stage.dispose();
+        return controller;
+    }
+
+    @Test
+    public void testItemAwardEveryThreeWins() throws Exception {
+        Player p = new Player("P");
+        Character c = new Character("C", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        p.addCharacter(c);
+        SaveLoadService.saveGame(new GameData(List.of(p), List.of()));
+
+        GameManagerController controller = buildController();
+        Player loaded = controller.getPlayers().get(0);
+        Character loadedChar = loaded.getCharacters().get(0);
+
+        controller.handlePlayerWin(loaded, loadedChar);
+        controller.handlePlayerWin(loaded, loadedChar);
+        assertEquals(0, loadedChar.getInventory().getAllItems().size());
+        controller.handlePlayerWin(loaded, loadedChar);
+        assertEquals(1, loadedChar.getInventory().getAllItems().size());
+        controller.handlePlayerWin(loaded, loadedChar);
+        controller.handlePlayerWin(loaded, loadedChar);
+        assertEquals(1, loadedChar.getInventory().getAllItems().size());
+        controller.handlePlayerWin(loaded, loadedChar);
+        assertEquals(2, loadedChar.getInventory().getAllItems().size());
+    }
+}

--- a/src/test/java/model/item/MagicItemEffectTest.java
+++ b/src/test/java/model/item/MagicItemEffectTest.java
@@ -1,0 +1,45 @@
+package model.item;
+
+import model.battle.CombatLog;
+import model.core.ClassType;
+import model.core.Character;
+import model.core.RaceType;
+import model.util.GameException;
+import model.util.StatusEffectType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MagicItemEffectTest {
+
+    @Test
+    public void testPotionOfMinorHealing() throws GameException {
+        Character c = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        c.takeDamage(30);
+        SingleUseItem item = new SingleUseItem("Potion of Minor Healing", "Heals", "Common",
+                SingleUseEffectType.HEAL_HP, 40);
+        item.applyEffect(c, new CombatLog());
+        assertEquals(c.getMaxHp(), c.getCurrentHp());
+    }
+
+    @Test
+    public void testScrollOfMinorEnergy() throws GameException {
+        Character c = new Character("B", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        c.spendEp(c.getCurrentEp());
+        SingleUseItem item = new SingleUseItem("Scroll of Minor Energy", "EP", "Common",
+                SingleUseEffectType.RESTORE_EP, 20);
+        item.applyEffect(c, new CombatLog());
+        assertEquals(20, c.getCurrentEp());
+    }
+
+    @Test
+    public void testDefendersAegisAppliesImmunity() throws GameException {
+        Character c = new Character("C", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        SingleUseItem item = new SingleUseItem("Defender's Aegis", "Immune", "Common",
+                SingleUseEffectType.GRANT_IMMUNITY, 1);
+        item.applyEffect(c, new CombatLog());
+        assertTrue(c.hasStatusEffect(StatusEffectType.IMMUNITY));
+    }
+}

--- a/src/test/java/model/item/MagicItemFactoryTest.java
+++ b/src/test/java/model/item/MagicItemFactoryTest.java
@@ -1,0 +1,31 @@
+package model.item;
+
+import model.service.MagicItemFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MagicItemFactoryTest {
+    private static class FixedRandom extends Random {
+        private final int[] values;
+        private int idx = 0;
+        FixedRandom(int... v) { this.values = v; }
+        @Override
+        public int nextInt(int bound) {
+            int val = values[idx++];
+            return val % bound;
+        }
+    }
+
+    @Test
+    public void testRarityBoundaries() {
+        MagicItem common = MagicItemFactory.createRandomReward(new FixedRandom(10,0));
+        assertEquals("Common", common.getRarity());
+        MagicItem uncommon = MagicItemFactory.createRandomReward(new FixedRandom(60,0));
+        assertEquals("Uncommon", uncommon.getRarity());
+        MagicItem rare = MagicItemFactory.createRandomReward(new FixedRandom(98,0));
+        assertEquals("Rare", rare.getRarity());
+    }
+}


### PR DESCRIPTION
## Summary
- add GRANT_IMMUNITY single-use effect
- implement new magic items and rarity probabilities
- update battle controller to apply new passive effects
- expose equipped item info in battle UI
- create tests for item effects, factory rarity, and reward drops

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688529316f288328928bffd297857f69