### PR TITLE
Hide bot controls in PvB battles

### DIFF
--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -258,8 +258,7 @@ public final class SceneManager {
 
     /** Displays a battle between two characters. */
     public void showPlayerVsBotBattle(Player humanPlayer, Character human, Character bot, AIController aiController) {
-        battleView = new BattleView(human, bot);
-        battleView.setPlayer2ControlsEnabled(false);
+        battleView = new BattleView(BattleView.BATTLE_PVB, human, bot);
         try {
             BattleController battleController = new BattleController(battleView, gameManagerController, humanPlayer, null);
             battleView.addUseAbilityP1Listener(e -> {

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -97,7 +97,14 @@ public class BattleView extends JFrame {
      * Convenience constructor using two characters. Defaults to PvP mode.
      */
     public BattleView(Character c1, Character c2) {
-        this(BATTLE_PVP);
+        this(BATTLE_PVP, c1, c2);
+    }
+
+    /**
+     * Constructs a battle view for the given mode and characters.
+     */
+    public BattleView(int mode, Character c1, Character c2) {
+        this(mode);
         this.char1 = c1;
         this.char2 = c2;
     }


### PR DESCRIPTION
## Summary
- fix SceneManager to instantiate BattleView in PvB mode
- add `BattleView(int, Character, Character)` constructor
- use the new constructor in the convenience version

## Testing
- `mvn -q test` *(fails: Maven dependencies can't be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68852dc3501c832897cdf067c99ea51a