### PR TITLE
Fix Hall of Fame screen navigation

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -112,10 +112,7 @@ public void actionPerformed(ActionEvent e) {
                 mainMenuView.dispose();
             }
         }
-        case MainMenuView.ACTION_HALL_OF_FAME -> {
-            sceneManager.showHallOfFameManagement(); // Show Hall of Fame View
-            mainMenuView.dispose(); // Close the MainMenuView
-        }
+        case MainMenuView.ACTION_HALL_OF_FAME -> showHallOfFameScreen();
         case MainMenuView.ACTION_START_BATTLE -> {
             if (players.isEmpty()) {
                 JOptionPane.showMessageDialog(mainMenuView, "Please register players first.", "Error", JOptionPane.ERROR_MESSAGE);
@@ -294,6 +291,22 @@ public void actionPerformed(ActionEvent e) {
             }
         }
         return null;
+    }
+
+    /**
+     * Navigates to the Hall of Fame management screen.
+     */
+    public void showHallOfFameScreen() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                sceneManager.showHallOfFameManagement();
+                mainMenuView.dispose();
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(mainMenuView,
+                        "Unable to open Hall of Fame: " + ex.getMessage(),
+                        "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        });
     }
 
 

--- a/controller/HallOfFameController.java
+++ b/controller/HallOfFameController.java
@@ -4,6 +4,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.swing.JOptionPane;
+
+import controller.SceneManager;
 
 import model.core.Player;
 import model.core.Character;
@@ -23,12 +26,15 @@ import view.HallOfFameManagementView;
 public class HallOfFameController implements ActionListener {
 
     private final HallOfFameManagementView view;
+    private final SceneManager sceneManager;
     private List<HallOfFameEntry> playerEntries;
     private List<HallOfFameEntry> characterEntries;
 
-    public HallOfFameController(HallOfFameManagementView view) {
+    public HallOfFameController(HallOfFameManagementView view, SceneManager sceneManager) {
         InputValidator.requireNonNull(view, "view");
+        InputValidator.requireNonNull(sceneManager, "sceneManager");
         this.view = view;
+        this.sceneManager = sceneManager;
 
         try {
             HallOfFameData data = SaveLoadService.loadHallOfFame();
@@ -37,6 +43,8 @@ public class HallOfFameController implements ActionListener {
         } catch (GameException e) {
             this.playerEntries = new ArrayList<>();
             this.characterEntries = new ArrayList<>();
+            JOptionPane.showMessageDialog(view, "Unable to load Hall of Fame: " + e.getMessage(),
+                    "Error", JOptionPane.ERROR_MESSAGE);
         }
 
         this.view.setController(this); // Connect view to this controller
@@ -195,7 +203,7 @@ public class HallOfFameController implements ActionListener {
         switch (command) {
             case HallOfFameManagementView.SHOW_TOP_PLAYERS -> showTopPlayers();
             case HallOfFameManagementView.SHOW_TOP_CHARACTERS -> showTopCharacters();
-            case HallOfFameManagementView.RETURN -> view.dispose();
+            case HallOfFameManagementView.RETURN -> sceneManager.showMainMenu();
             default -> view.showErrorMessage("Unknown action: " + command);
         }
     }

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -28,6 +28,7 @@ import controller.PlayerDeleteController;
 import controller.CharacterManagementMenuController;
 import controller.BattleModesController;
 import controller.BattleController;
+import controller.HallOfFameController;
 import controller.AIController;
 
 public final class SceneManager {
@@ -62,6 +63,7 @@ public final class SceneManager {
     private PlayerDeleteView playerDeleteView;
     private PlayerDeleteController playerDeleteController;
     private view.BattleModesView battleModesView;
+    private HallOfFameController hallOfFameController;
 
     private GameManagerController gameManagerController; // Keep the controller instance here
 
@@ -88,11 +90,14 @@ public final class SceneManager {
     public void showMainMenu() {
         if (mainMenuView == null) {
             mainMenuView = new MainMenuView();
-
             // Initialize the controller only once
             hallOfFameView = new HallOfFameManagementView();
+            hallOfFameController = new HallOfFameController(hallOfFameView, this);
+            hallOfFameView.setActionListener(hallOfFameController);
+            root.add(hallOfFameView.getContentPane(), CARD_HALL_OF_FAME);
+
             if (gameManagerController == null) {
-                gameManagerController = new GameManagerController(this, new HallOfFameController(hallOfFameView), mainMenuView);
+                gameManagerController = new GameManagerController(this, hallOfFameController, mainMenuView);
             }
             mainMenuView.setActionListener(gameManagerController);
             root.add(mainMenuView.getContentPane(), CARD_MAIN_MENU);
@@ -205,8 +210,12 @@ public final class SceneManager {
     public void showHallOfFameManagement() {
         if (hallOfFameView == null) {
             hallOfFameView = new HallOfFameManagementView();
-            HallOfFameController controller = new HallOfFameController(hallOfFameView);
-            hallOfFameView.setActionListener(controller);
+        }
+        if (hallOfFameController == null) {
+            hallOfFameController = new HallOfFameController(hallOfFameView, this);
+            hallOfFameView.setActionListener(hallOfFameController);
+        }
+        if (hallOfFameView.getContentPane().getParent() == null) {
             root.add(hallOfFameView.getContentPane(), CARD_HALL_OF_FAME);
         }
         cards.show(root, CARD_HALL_OF_FAME);


### PR DESCRIPTION
## Summary
- register the Hall of Fame view card when the main menu is created
- allow returning from Hall of Fame to main menu
- add a controller helper method to show the Hall of Fame screen
- surface load errors for the Hall of Fame

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68853cdfa75883289acffb38b0e3da83