### PR TITLE
Implement Hall of Fame persistence migration

### DIFF
--- a/controller/HallOfFameController.java
+++ b/controller/HallOfFameController.java
@@ -4,6 +4,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import javax.swing.JOptionPane;
 
 import controller.SceneManager;
@@ -159,12 +162,18 @@ public class HallOfFameController implements ActionListener {
         try {
             List<HallOfFameEntry> topCharacters = getTopCharactersByWins(10);
             if (topCharacters.isEmpty()) {
-                view.updateTopCharactersList("No top characters yet.");
+                view.updateTopCharactersList("No records yet!");
             } else {
-                String content = topCharacters.stream()
-                        .map(HallOfFameEntry::toString)
-                        .collect(Collectors.joining("\n\n"));
-                view.updateTopCharactersList(content);
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < topCharacters.size(); i++) {
+                    HallOfFameEntry e = topCharacters.get(i);
+                    String date = LocalDateTime.ofInstant(Instant.ofEpochMilli(e.getLastUpdated()),
+                            ZoneId.systemDefault()).toLocalDate().toString();
+                    sb.append(String.format("%d. %s - Wins: %d, XP: %d, Last Win: %s",
+                            i + 1, e.getName(), e.getWins(), e.getXp(), date));
+                    if (i < topCharacters.size() - 1) sb.append("\n\n");
+                }
+                view.updateTopCharactersList(sb.toString());
             }
         } catch (GameException e) {
             view.updateTopCharactersList("Unable to load Hall of Fame.");
@@ -184,12 +193,18 @@ public class HallOfFameController implements ActionListener {
         try {
             List<HallOfFameEntry> topPlayers = getTopPlayersByWins(10);
             if (topPlayers.isEmpty()) {
-                view.updateTopPlayersList("No top players yet.");
+                view.updateTopPlayersList("No records yet!");
             } else {
-                String content = topPlayers.stream()
-                        .map(HallOfFameEntry::toString)
-                        .collect(Collectors.joining("\n\n"));
-                view.updateTopPlayersList(content);
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < topPlayers.size(); i++) {
+                    HallOfFameEntry e = topPlayers.get(i);
+                    String date = LocalDateTime.ofInstant(Instant.ofEpochMilli(e.getLastUpdated()),
+                            ZoneId.systemDefault()).toLocalDate().toString();
+                    sb.append(String.format("%d. %s - Wins: %d, XP: %d, Last Win: %s",
+                            i + 1, e.getName(), e.getWins(), e.getXp(), date));
+                    if (i < topPlayers.size() - 1) sb.append("\n\n");
+                }
+                view.updateTopPlayersList(sb.toString());
             }
         } catch (GameException e) {
             view.updateTopPlayersList("Unable to load Hall of Fame.");

--- a/src/test/java/persistence/HallOfFameMigrationTest.java
+++ b/src/test/java/persistence/HallOfFameMigrationTest.java
@@ -1,0 +1,33 @@
+package persistence;
+
+import model.core.HallOfFameEntry;
+import model.util.GameException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Verifies legacy Hall of Fame data is loaded without errors. */
+public class HallOfFameMigrationTest {
+
+    @AfterEach
+    public void cleanup() {
+        new java.io.File("save/hall_of_fame.dat").delete();
+    }
+
+    @Test
+    public void testLegacyListUpgrade() throws Exception {
+        HallOfFameEntry entry = new HallOfFameEntry("Legacy", 5, 42, 1L);
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream("save/hall_of_fame.dat"))) {
+            out.writeObject(List.of(entry));
+        }
+
+        HallOfFameData data = SaveLoadService.loadHallOfFame();
+        assertEquals(1, data.getPlayers().size());
+        assertEquals("Legacy", data.getPlayers().get(0).getName());
+    }
+}


### PR DESCRIPTION
## Summary
- extend `SaveLoadService.loadHallOfFame` with backward‑compatibility for old files
- improve Hall of Fame UI formatting and blank state messages
- add migration unit test for legacy leaderboard format

## Testing
- `mvn test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_688545ca7ef08328b22c18628054d049