### PR TITLE
Fix trading hall to open TradeView window correctly

### DIFF
--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -235,29 +235,48 @@ public final class SceneManager {
         cards.show(root, CARD_TRADING_HALL);
     }
 
-    /** Displays the full TradeView for two characters. */
-    public void showTradeView(model.core.Character merchant,
-                              model.core.Character client,
-                              List<Player> players) {
-        tradeView = new TradeView(merchant, client);
+    /**
+     * Opens a separate {@link TradeView} window for the two selected players.
+     * The Trading Hall view is disposed before launching the trade window.
+     * When the trade concludes the main stage size is reset and the user is
+     * returned to the Trading Hall.
+     */
+    public void showTradeView(Player merchant, Player client) {
+        System.out.println("SceneManager.showTradeView merchant="
+                + merchant.getName() + ", client=" + client.getName());
+
+        if (tradingHallView != null) {
+            tradingHallView.dispose();
+        }
+        stage.setVisible(false);
+
+        model.core.Character mChar = merchant.getCharacters().isEmpty()
+                ? null : merchant.getCharacters().getFirst();
+        model.core.Character cChar = client.getCharacters().isEmpty()
+                ? null : client.getCharacters().getFirst();
+
+        tradeView = new TradeView(mChar, cChar);
         try {
-            tradeController = new TradeController(tradeView, players);
+            tradeController = new TradeController(tradeView,
+                    gameManagerController.getPlayers());
         } catch (GameException e) {
-            JOptionPane.showMessageDialog(stage, "Unable to open trade view: " + e.getMessage(),
+            JOptionPane.showMessageDialog(stage,
+                    "Unable to open trade view: " + e.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
             return;
         }
+
         tradeView.setActionListener(e -> {
             String cmd = e.getActionCommand();
             if (TradeView.RETURN.equals(cmd)) {
-                showTradingHall(players);
+                tradeView.dispose();
+                stage.setSize(800, 700);
+                stage.setVisible(true);
+                showTradingHall(gameManagerController.getPlayers());
             }
         });
-        if (tradeView.getContentPane().getParent() == null) {
-            root.add(tradeView.getContentPane(), CARD_TRADE_VIEW);
-        }
-        stage.setSize(990, 529);
-        cards.show(root, CARD_TRADE_VIEW);
+
+        tradeView.setVisible(true);
     }
 
     /** Shows the menu to pick which player's characters to manage. */

--- a/controller/TradingHallController.java
+++ b/controller/TradingHallController.java
@@ -46,6 +46,7 @@ public class TradingHallController implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         String cmd = e.getActionCommand();
+        System.out.println("TradingHallController action: " + cmd);
         if (TradingHallView.RETURN_TO_MENU.equals(cmd)) {
             view.dispose();
             sceneManager.showMainMenu();
@@ -80,10 +81,10 @@ public class TradingHallController implements ActionListener {
                     "Invalid Selection", JOptionPane.ERROR_MESSAGE);
             return;
         }
-        model.core.Character mChar = p1.getCharacters().get(0);
-        model.core.Character cChar = p2.getCharacters().get(0);
+        System.out.println("TradingHallController starting trade between "
+                + p1.getName() + " and " + p2.getName());
         view.dispose();
-        sceneManager.showTradeView(mChar, cChar, players);
+        sceneManager.showTradeView(p1, p2);
     }
 
     private Player findPlayerByName(String name) {

--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -2,6 +2,7 @@ package view;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.stream.Collectors;
 import javax.swing.*;
 
 // import controller._;
@@ -10,6 +11,9 @@ import javax.swing.*;
  * The trading view for Fatal Fantasy: Tactics Game.
  */
 public class TradingView extends JFrame {
+
+    private model.core.Character merchant;
+    private model.core.Character client;
 
     // Button labels
     public static final String TRADE = "Trade";
@@ -51,6 +55,18 @@ public class TradingView extends JFrame {
 
         setLocationRelativeTo(null);
         setResizable(false);
+        System.out.println("TradingView default constructor");
+    }
+
+    /** Convenience constructor wiring the merchant and client characters. */
+    public TradingView(model.core.Character merchant, model.core.Character client) {
+        this();
+        this.merchant = merchant;
+        this.client = client;
+        System.out.println("TradingView created for merchant="
+                + (merchant != null ? merchant.getName() : "null") +
+                ", client=" + (client != null ? client.getName() : "null"));
+        populateInitialData();
         setVisible(true);
     }
 
@@ -294,6 +310,8 @@ public class TradingView extends JFrame {
         // Bottom Panel Buttons
         btnTrade.addActionListener(listener);
         btnReturn.addActionListener(listener);
+        btnTrade.setActionCommand(TRADE);
+        btnReturn.setActionCommand(RETURN);
     }
 
 
@@ -345,6 +363,24 @@ public class TradingView extends JFrame {
             case 1 -> p0ItemsArea.setText(items);
             case 2 -> t0ItemsArea.setText(items);
         }
+    }
+
+    /** Populates UI fields with the merchant and client data. */
+    private void populateInitialData() {
+        if (merchant != null) {
+            setPlayerTraderName(1, merchant.getName());
+            setPlayerTraderItems(1, buildItemsList(merchant));
+        }
+        if (client != null) {
+            setPlayerTraderName(2, client.getName());
+            setPlayerTraderItems(2, buildItemsList(client));
+        }
+    }
+
+    private String buildItemsList(model.core.Character c) {
+        return c.getInventory().getAllItems().stream()
+                .map(model.item.MagicItem::getName)
+                .collect(java.util.stream.Collectors.joining(", "));
     }
 
 


### PR DESCRIPTION
## Summary
- open a dedicated TradeView window when trading starts
- dispose the Trading Hall and hide the main stage
- populate TradeView with selected character data
- wire action commands and debug output for easier tracing

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6885ed2a00f88328b2978bba43bff85c