### PR TITLE
Add equality semantics to MagicItem

### DIFF
--- a/model/item/MagicItem.java
+++ b/model/item/MagicItem.java
@@ -84,6 +84,35 @@ public abstract class MagicItem implements Serializable {
     }
 
     /**
+     * Determines equality based on immutable item properties and concrete type.
+     * Two items are considered equal if they are of the same class and all
+     * core fields match.
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are logically equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MagicItem that = (MagicItem) o;
+        return name.equals(that.name)
+                && description.equals(that.description)
+                && itemType == that.itemType
+                && rarity.equals(that.rarity);
+    }
+
+    /**
+     * Computes a hash code consistent with {@link #equals(Object)}.
+     *
+     * @return hash code based on immutable fields
+     */
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(name, description, itemType, rarity);
+    }
+
+    /**
      * Returns a short display string including name and type.
      */
     @Override

--- a/model/item/SingleUseItem.java
+++ b/model/item/SingleUseItem.java
@@ -68,6 +68,31 @@ public final class SingleUseItem extends MagicItem {
         return effectValue;
     }
 
+    /**
+     * Two {@code SingleUseItem}s are equal when all base properties and the
+     * effect type/value match.
+     *
+     * @param o object to compare
+     * @return {@code true} when logically equivalent
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        if (getClass() != o.getClass()) return false;
+        SingleUseItem that = (SingleUseItem) o;
+        return effectValue == that.effectValue && effectType == that.effectType;
+    }
+
+    /**
+     * Hash code consistent with {@link #equals(Object)} including effect fields.
+     *
+     * @return computed hash value
+     */
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(super.hashCode(), effectType, effectValue);
+    }
+
 
 
     /**


### PR DESCRIPTION
## Summary
- implement `equals` and `hashCode` in `MagicItem`
- override equality methods in `SingleUseItem`

## Testing
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688629d84f9c832893634daa75892b22