### PR TITLE
Step3: integrate inventory with Character

### DIFF
--- a/model/item/Inventory.java
+++ b/model/item/Inventory.java
@@ -77,6 +77,17 @@ public final class Inventory implements Serializable {
     }
 
     /**
+     * Checks if the inventory currently contains the given item.
+     *
+     * @param item the item to check for (non-null)
+     * @return {@code true} if present, otherwise {@code false}
+     */
+    public boolean hasItem(MagicItem item) {
+        InputValidator.requireNonNull(item, "Item to check");
+        return items.contains(item);
+    }
+
+    /**
      * Adds a new magic item to the inventory.
      *
      * @param item The non-null item to add.

--- a/src/test/java/model/core/CharacterInventoryTest.java
+++ b/src/test/java/model/core/CharacterInventoryTest.java
@@ -1,0 +1,41 @@
+package model.core;
+
+import model.item.PassiveItem;
+import model.item.SingleUseEffectType;
+import model.item.SingleUseItem;
+import model.util.GameException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link Character} inventory delegation methods.
+ */
+public class CharacterInventoryTest {
+
+    @Test
+    public void testEquipAndUnequipDelegation() throws GameException {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        PassiveItem ring = new PassiveItem("Ring", "", "Common");
+        c.getInventory().addItem(ring);
+
+        c.equipItem(ring);
+        assertEquals(ring, c.getEquippedItem());
+
+        c.unequipItem();
+        assertNull(c.getEquippedItem());
+    }
+
+    @Test
+    public void testHasItemAndUseSingleUseItem() throws GameException {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        SingleUseItem potion = new SingleUseItem("Potion", "", "Common", SingleUseEffectType.HEAL_HP, 10);
+        c.getInventory().addItem(potion);
+
+        assertTrue(c.hasItem(potion));
+        c.useSingleUseItem(potion);
+        assertFalse(c.hasItem(potion));
+    }
+}


### PR DESCRIPTION
## Summary
- delegate equipped item handling from Character to Inventory
- add Inventory.hasItem helper
- expose Character wrappers for equip/unequip/use item
- unit tests for Character inventory integration

## Testing
- `mvn -q -Dtest=CharacterInventoryTest test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68862bc3c25c8328ba1909908174489a