### PR TITLE
Remove solid backgrounds from display panels

### DIFF
--- a/view/CharacterManagementView.java
+++ b/view/CharacterManagementView.java
@@ -114,7 +114,10 @@ public class CharacterManagementView extends JFrame {
         characterListArea = new JTextArea(12, 40);
         characterListArea.setEditable(false);
         characterListArea.setFont(new Font("Monospaced", Font.PLAIN, 15));
+        characterListArea.setOpaque(false);
         JScrollPane scrollPane = new JScrollPane(characterListArea);
+        scrollPane.setOpaque(false);
+        scrollPane.getViewport().setOpaque(false);
         scrollPane.setAlignmentX(Component.CENTER_ALIGNMENT);
         scrollPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         centerPanel.add(scrollPane);

--- a/view/InventoryView.java
+++ b/view/InventoryView.java
@@ -135,6 +135,7 @@ public class InventoryView extends JFrame{
         detailsPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         itemList = new JList<>(listModel);
+        itemList.setOpaque(false);
         itemList.setFont(new Font("Serif", Font.BOLD, 18));
         itemList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         itemList.setCellRenderer(new DefaultListCellRenderer() {

--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -264,6 +264,7 @@ public class TradeView extends JFrame {
         label.setFont(new Font("Serif", Font.BOLD, 17));
 
         list.setFont(new Font("Serif", Font.BOLD, 18));
+        list.setOpaque(false);
         list.setVisibleRowCount(6);
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         list.setCellRenderer(new DefaultListCellRenderer() {


### PR DESCRIPTION
## Summary
- ensure InventoryView item list is transparent
- make trade item list transparent
- remove opaque background in CharacterManagementView list

## Testing
- `mvn test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6886491daa708328a494c052af5bf368