### PR TITLE
Remove use button from InventoryView

### DIFF
--- a/controller/InventoryController.java
+++ b/controller/InventoryController.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import model.core.Character;
 import model.item.MagicItem;
-import model.item.SingleUseItem;
 import model.util.GameException;
 import model.util.InputValidator;
 import view.InventoryView;
@@ -16,7 +15,7 @@ import controller.GameManagerController;
 
 /**
  * Controller responsible for handling inventory-related actions
- * such as equipping magic items, unequipping, and using single-use items.
+ * such as equipping and unequipping magic items.
  * <p>
  * Acts as the intermediary between the GUI and the model layer's
  * inventory functionality, enforcing validation and encapsulation.
@@ -105,24 +104,6 @@ public final class InventoryController implements ActionListener {
         refreshInventoryDisplay();
     }
 
-    /**
-     * Handles a request to use a {@link SingleUseItem}.
-     * The item is consumed immediately upon use.
-     *
-     * @param itemToUse the single-use item to activate (non-null)
-     * @throws GameException if {@code itemToUse} is {@code null}
-     */
-    public void handleUseSingleUseItem(SingleUseItem itemToUse) {
-        try {
-            InputValidator.requireNonNull(itemToUse, "use item");
-            character.getInventory().useSingleUseItem(itemToUse);
-            persist();
-            refreshInventoryDisplay();
-        } catch (GameException e) {
-            if (view != null) view.showErrorMessage(e.getMessage());
-        }
-    }
-
     private void persist() {
         if (gameManagerController != null) {
             gameManagerController.handleSaveGameRequest();
@@ -139,13 +120,6 @@ public final class InventoryController implements ActionListener {
             if (sel != null) handleEquipItem(sel);
         } else if (InventoryView.UNEQUIP.equals(cmd)) {
             handleUnequipItem();
-        } else if (InventoryView.USE.equals(cmd)) {
-            MagicItem sel = view.getSelectedItem();
-            if (sel instanceof SingleUseItem sui) {
-                handleUseSingleUseItem(sui);
-            } else if (view != null) {
-                view.showErrorMessage("Selected item cannot be used.");
-            }
         }
     }
 }

--- a/view/InventoryView.java
+++ b/view/InventoryView.java
@@ -38,13 +38,11 @@ public class InventoryView extends JFrame{
     // Button labels
     public static final String EQUIP = "Equip";
     public static final String UNEQUIP = "Unequip";
-    public static final String USE = "Use";
     public static final String RETURN = "Return";
 
     // UI components
     private JButton btnEquip;
     private JButton btnUnequip;
-    private JButton btnUse;
     private JButton btnReturn;
     private final DefaultListModel<model.item.MagicItem> listModel = new DefaultListModel<>();
     private JList<model.item.MagicItem> itemList;
@@ -157,6 +155,10 @@ public class InventoryView extends JFrame{
 
         detailsPanel.add(scrollPane, BorderLayout.CENTER);
 
+        JLabel tipLabel = new JLabel("Single-use items may only be used in battle.");
+        tipLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        detailsPanel.add(tipLabel, BorderLayout.SOUTH);
+
         centerPanel.add(detailsPanel);
         centerPanel.add(Box.createVerticalGlue());
 
@@ -168,12 +170,10 @@ public class InventoryView extends JFrame{
 
         btnEquip = new RoundedButton(EQUIP);
         btnUnequip = new RoundedButton(UNEQUIP);
-        btnUse = new RoundedButton(USE);
         btnReturn = new RoundedButton(RETURN);
 
         buttonPanel.add(btnEquip);
         buttonPanel.add(btnUnequip);
-        buttonPanel.add(btnUse);
         buttonPanel.add(btnReturn);
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
@@ -190,12 +190,10 @@ public class InventoryView extends JFrame{
     public void setActionListener(ActionListener listener) {
         btnEquip.setActionCommand(EQUIP);
         btnUnequip.setActionCommand(UNEQUIP);
-        btnUse.setActionCommand(USE);
         btnReturn.setActionCommand(RETURN);
 
         btnEquip.addActionListener(listener);
         btnUnequip.addActionListener(listener);
-        btnUse.addActionListener(listener);
         btnReturn.addActionListener(listener);
     }
 


### PR DESCRIPTION
## Summary
- strip out `Use` button from inventory screen
- update controller to remove dead code for using items through inventory
- show a small note that single-use items are only for battle

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not resolve dependencies)*
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68864d7691e08328b796edae9d2278ca