### PR TITLE
Add reward item on wins and item detail view

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -418,12 +418,18 @@ public void actionPerformed(ActionEvent e) {
             }
 
             winner.incrementWins();
+            character.recordWin();
             hallOfFameController.addWinForPlayer(winner);
             hallOfFameController.addWinForCharacter(character);
 
-            if (winner.getCumulativeWins() % Constants.WINS_PER_REWARD == 0) {
-                MagicItem reward = MagicItemFactory.createRandomReward();
+            if (character.getWinCount() % Constants.WINS_PER_REWARD == 0) {
+                MagicItem reward = generateUniqueReward(character);
                 character.getInventory().addItem(reward);
+                javax.swing.JOptionPane.showMessageDialog(null,
+                        "New Magic Item awarded: " + reward.getName() +
+                        "\n" + reward.getDescription(),
+                        "Item Awarded",
+                        javax.swing.JOptionPane.INFORMATION_MESSAGE);
             }
 
             SaveLoadService.saveGame(new GameData(players,
@@ -433,5 +439,20 @@ public void actionPerformed(ActionEvent e) {
                     "Failed to record win: " + e.getMessage(),
                     "Win Error", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    /**
+     * Generates a random magic item not already held by the character, if
+     * possible. Falls back to any random item after several attempts.
+     */
+    private MagicItem generateUniqueReward(Character character) {
+        java.util.List<MagicItem> owned = character.getInventory().getAllItems();
+        MagicItem reward = MagicItemFactory.createRandomReward();
+        int attempts = 0;
+        while (owned.contains(reward) && attempts < 10) {
+            reward = MagicItemFactory.createRandomReward();
+            attempts++;
+        }
+        return reward;
     }
 }

--- a/controller/InventoryController.java
+++ b/controller/InventoryController.java
@@ -146,6 +146,11 @@ public final class InventoryController implements ActionListener {
             } else if (view != null) {
                 view.showErrorMessage("Selected item cannot be used.");
             }
+        } else if (InventoryView.VIEW.equals(cmd)) {
+            MagicItem sel = view.getSelectedItem();
+            if (sel != null) {
+                view.showMagicItemDetails(sel);
+            }
         }
     }
 }

--- a/view/InventoryView.java
+++ b/view/InventoryView.java
@@ -39,12 +39,14 @@ public class InventoryView extends JFrame{
     public static final String EQUIP = "Equip";
     public static final String UNEQUIP = "Unequip";
     public static final String USE = "Use";
+    public static final String VIEW = "View Magic Item";
     public static final String RETURN = "Return";
 
     // UI components
     private JButton btnEquip;
     private JButton btnUnequip;
     private JButton btnUse;
+    private JButton btnView;
     private JButton btnReturn;
     private final DefaultListModel<model.item.MagicItem> listModel = new DefaultListModel<>();
     private JList<model.item.MagicItem> itemList;
@@ -144,6 +146,7 @@ public class InventoryView extends JFrame{
                 super.getListCellRendererComponent(l, val, idx, sel, foc);
                 if (val instanceof model.item.MagicItem mi) {
                     setText((idx + 1) + ". " + mi.getName());
+                    setToolTipText(mi.getDescription());
                 }
                 return this;
             }
@@ -169,11 +172,13 @@ public class InventoryView extends JFrame{
         btnEquip = new RoundedButton(EQUIP);
         btnUnequip = new RoundedButton(UNEQUIP);
         btnUse = new RoundedButton(USE);
+        btnView = new RoundedButton(VIEW);
         btnReturn = new RoundedButton(RETURN);
 
         buttonPanel.add(btnEquip);
         buttonPanel.add(btnUnequip);
         buttonPanel.add(btnUse);
+        buttonPanel.add(btnView);
         buttonPanel.add(btnReturn);
 
         backgroundPanel.add(buttonPanel, BorderLayout.SOUTH);
@@ -191,11 +196,13 @@ public class InventoryView extends JFrame{
         btnEquip.setActionCommand(EQUIP);
         btnUnequip.setActionCommand(UNEQUIP);
         btnUse.setActionCommand(USE);
+        btnView.setActionCommand(VIEW);
         btnReturn.setActionCommand(RETURN);
 
         btnEquip.addActionListener(listener);
         btnUnequip.addActionListener(listener);
         btnUse.addActionListener(listener);
+        btnView.addActionListener(listener);
         btnReturn.addActionListener(listener);
     }
 
@@ -212,6 +219,7 @@ public class InventoryView extends JFrame{
                     String name = mi.getName();
                     if (mi.equals(equipped)) name += " (Equipped)";
                     setText((idx + 1) + ". " + name);
+                    setToolTipText(mi.getDescription());
                 }
                 return this;
             }
@@ -221,6 +229,16 @@ public class InventoryView extends JFrame{
     /** Returns the currently selected item or {@code null}. */
     public model.item.MagicItem getSelectedItem() {
         return itemList.getSelectedValue();
+    }
+
+    /** Displays a dialog showing full details for the provided item. */
+    public void showMagicItemDetails(model.item.MagicItem item) {
+        if (item == null) return;
+        String msg = item.getName() + "\nType: " + item.getItemType() +
+                "\nRarity: " + item.getRarity() +
+                "\n\n" + item.getDescription();
+        JOptionPane.showMessageDialog(this, msg, "Magic Item Details",
+                JOptionPane.INFORMATION_MESSAGE);
     }
 
     public void showInfoMessage(String msg) {


### PR DESCRIPTION
## Summary
- award a random magic item after every third win and track win count on characters
- show the reward in a dialog and avoid duplicates when possible
- allow viewing magic item details in Inventory view

## Testing
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68864dc472a08328b86369b1316467f8