### PR TITLE
Add SmartBot AI for PvB mode

### DIFF
--- a/controller/BattleSetupController.java
+++ b/controller/BattleSetupController.java
@@ -5,7 +5,7 @@ import model.core.Player;
 import model.util.DialogUtils;
 import model.util.GameException;
 import model.util.RandomCharacterGenerator;
-import model.util.SimpleBot;
+import model.util.SmartBot;
 import view.BattleCharSelectionView;
 
 import java.util.List;
@@ -67,7 +67,7 @@ public class BattleSetupController {
     private void launchPvB() {
         try {
             Character bot = RandomCharacterGenerator.generate("Bot");
-            AIController ai = new AIController(new SimpleBot(new Random()));
+            AIController ai = new AIController(new SmartBot(new Random()));
             sceneManager.showPlayerVsBotBattle(players.get(0), p1Char, bot, ai);
         } catch (GameException e) {
             DialogUtils.showErrorDialog("Battle Error", e.getMessage());

--- a/model/util/SmartBot.java
+++ b/model/util/SmartBot.java
@@ -1,0 +1,137 @@
+package model.util;
+
+import model.battle.AbilityMove;
+import model.battle.ItemMove;
+import model.battle.Move;
+import model.battle.Recharge;
+import model.core.Ability;
+import model.core.AbilityEffectType;
+import model.core.Character;
+import model.item.MagicItem;
+import model.item.SingleUseItem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * <h2>SmartBot</h2>
+ *
+ * <p>Heuristic based AI strategy that chooses sensible actions
+ * depending on the current battle state. It prioritises healing
+ * when wounded, restoring energy when low, and attacking otherwise.
+ * Randomness is injected to avoid deterministic play.</p>
+ */
+public final class SmartBot implements AIMoveStrategy {
+
+    /** Random generator used for tie‑breakers. */
+    private final Random random;
+
+    /**
+     * Constructs a {@code SmartBot} using the supplied random source.
+     *
+     * @param random non-null {@link Random} instance
+     * @throws GameException if {@code random} is null
+     */
+    public SmartBot(Random random) throws GameException {
+        InputValidator.requireNonNull(random, "Random");
+        this.random = random;
+    }
+
+    @Override
+    public Move decideMove(Character bot, Character opponent) throws GameException {
+        InputValidator.requireNonNull(bot, "botCharacter");
+        InputValidator.requireNonNull(opponent, "opponentCharacter");
+
+        List<Move> healingMoves = new ArrayList<>();
+        List<Move> attackMoves = new ArrayList<>();
+        List<Move> energyMoves = new ArrayList<>();
+        List<Move> defensiveMoves = new ArrayList<>();
+
+        for (Ability a : bot.getAbilities()) {
+            if (a.getEpCost() > bot.getCurrentEp()) continue;
+            switch (a.getAbilityEffectType()) {
+                case HEAL -> healingMoves.add(new AbilityMove(a));
+                case ENERGY_GAIN -> energyMoves.add(new AbilityMove(a));
+                case DEFENSE, EVADE -> defensiveMoves.add(new AbilityMove(a));
+                default -> attackMoves.add(new AbilityMove(a));
+            }
+        }
+
+        for (MagicItem item : bot.getInventory().getAllItems()) {
+            if (item instanceof SingleUseItem su) {
+                switch (su.getEffectType()) {
+                    case HEAL_HP -> healingMoves.add(new ItemMove(su));
+                    case RESTORE_EP -> energyMoves.add(new ItemMove(su));
+                    case GRANT_IMMUNITY -> defensiveMoves.add(new ItemMove(su));
+                    default -> {}
+                }
+            }
+        }
+
+        int maxHp = bot.getMaxHp();
+        int curHp = bot.getCurrentHp();
+        int curEp = bot.getCurrentEp();
+
+        int minAbilityCost = bot.getAbilities().stream()
+                .mapToInt(Ability::getEpCost)
+                .filter(c -> c > 0)
+                .min().orElse(0);
+
+        if (curHp <= maxHp / 3 && !healingMoves.isEmpty()) {
+            return randomPick(healingMoves);
+        }
+
+        if (curEp < minAbilityCost && !energyMoves.isEmpty()) {
+            return randomPick(energyMoves);
+        }
+
+        // Opportunistic kill
+        Move lethal = attackMoves.stream()
+                .filter(m -> m instanceof AbilityMove)
+                .map(m -> (AbilityMove) m)
+                .filter(am -> am.getAbility().getAbilityEffectType() == AbilityEffectType.DAMAGE)
+                .filter(am -> am.getAbility().getEffectValue() >= opponent.getCurrentHp())
+                .findFirst()
+                .orElse(null);
+        if (lethal != null) return lethal;
+
+        if (!attackMoves.isEmpty()) {
+            return chooseHighestDamage(attackMoves);
+        }
+
+        if (!defensiveMoves.isEmpty()) {
+            return randomPick(defensiveMoves);
+        }
+
+        if (!energyMoves.isEmpty() && curEp < bot.getMaxEp()) {
+            return randomPick(energyMoves);
+        }
+
+        return new Recharge();
+    }
+
+    private Move chooseHighestDamage(List<Move> attacks) {
+        int best = -1;
+        List<Move> bestMoves = new ArrayList<>();
+        for (Move m : attacks) {
+            int dmg = 0;
+            if (m instanceof AbilityMove am &&
+                    am.getAbility().getAbilityEffectType() == AbilityEffectType.DAMAGE) {
+                dmg = am.getAbility().getEffectValue();
+            }
+            if (dmg > best) {
+                best = dmg;
+                bestMoves.clear();
+                bestMoves.add(m);
+            } else if (dmg == best) {
+                bestMoves.add(m);
+            }
+        }
+        return randomPick(bestMoves.isEmpty() ? attacks : bestMoves);
+    }
+
+    private Move randomPick(List<Move> moves) {
+        return moves.get(random.nextInt(moves.size()));
+    }
+}

--- a/src/test/java/model/util/SmartBotTest.java
+++ b/src/test/java/model/util/SmartBotTest.java
@@ -1,0 +1,69 @@
+package model.util;
+
+import model.battle.Move;
+import model.battle.Recharge;
+import model.battle.AbilityMove;
+import model.core.Ability;
+import model.core.AbilityEffectType;
+import model.core.ClassType;
+import model.core.Character;
+import model.core.RaceType;
+import model.util.StatusEffectType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for SmartBot decision making. */
+public class SmartBotTest {
+
+    private Character buildBot(List<Ability> abilities) throws GameException {
+        Character c = new Character("Bot", RaceType.HUMAN, ClassType.WARRIOR, abilities);
+        return c;
+    }
+
+    private Character buildOpponent() throws GameException {
+        return new Character("Opp", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+    }
+
+    @Test
+    public void testHealWhenLowHp() throws Exception {
+        Ability heal = new Ability("Heal", "heal", 5, AbilityEffectType.HEAL, 30, StatusEffectType.NONE);
+        Ability atk = new Ability("Hit", "hit", 5, AbilityEffectType.DAMAGE, 20, StatusEffectType.NONE);
+        Character bot = buildBot(List.of(heal, atk));
+        bot.takeDamage(80); // low HP
+        Character opp = buildOpponent();
+
+        SmartBot sb = new SmartBot(new Random(0));
+        Move m = sb.decideMove(bot, opp);
+        assertTrue(m instanceof AbilityMove);
+        assertEquals(AbilityEffectType.HEAL, ((AbilityMove) m).getAbility().getAbilityEffectType());
+    }
+
+    @Test
+    public void testRechargeWhenNoOptions() throws Exception {
+        Ability atk = new Ability("Hit", "hit", 20, AbilityEffectType.DAMAGE, 20, StatusEffectType.NONE);
+        Character bot = buildBot(List.of(atk));
+        bot.spendEp(bot.getCurrentEp()); // 0 EP
+        Character opp = buildOpponent();
+
+        SmartBot sb = new SmartBot(new Random(0));
+        Move m = sb.decideMove(bot, opp);
+        assertTrue(m instanceof Recharge);
+    }
+
+    @Test
+    public void testAttackWhenHealthy() throws Exception {
+        Ability heal = new Ability("Heal", "heal", 5, AbilityEffectType.HEAL, 30, StatusEffectType.NONE);
+        Ability atk = new Ability("Hit", "hit", 5, AbilityEffectType.DAMAGE, 20, StatusEffectType.NONE);
+        Character bot = buildBot(List.of(heal, atk));
+        Character opp = buildOpponent();
+
+        SmartBot sb = new SmartBot(new Random(0));
+        Move m = sb.decideMove(bot, opp);
+        assertTrue(m instanceof AbilityMove);
+        assertEquals(AbilityEffectType.DAMAGE, ((AbilityMove) m).getAbility().getAbilityEffectType());
+    }
+}


### PR DESCRIPTION
## Summary
- add a heuristic-based `SmartBot` implementing `AIMoveStrategy`
- integrate SmartBot into PvB battles
- create tests for SmartBot behaviour

## Testing
- `mvn -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886d07529808328ac5fa36ce4a84228