### PR TITLE
Fix PvB bot ability handling and display

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -144,6 +144,7 @@ public final class BattleController {
         InputValidator.requireNonNull(ai, "aiController");
 
         startBattle(human, bot);
+        view.setPlayer2ControlsEnabled(false);
         this.aiController = ai;
         // battleC1/battleC2 now reference the copies created in startBattle
         this.aiCharacter = battleC2;
@@ -203,9 +204,15 @@ public final class BattleController {
             }
         }
 
-        // Otherwise treat as ability name
+        // Otherwise treat as ability name (strip details if present)
+        String abilityName = choice;
+        int idx = abilityName.indexOf(" (EP:");
+        if (idx > 0) {
+            abilityName = abilityName.substring(0, idx);
+        }
+
         Optional<Ability> abilityOpt = user.getAbilities().stream()
-                .filter(a -> a.getName().equals(choice))
+                .filter(a -> a.getName().equals(abilityName))
                 .findFirst();
         if (abilityOpt.isPresent()) {
             Ability a = abilityOpt.get();
@@ -480,7 +487,9 @@ public final class BattleController {
     private List<String> abilityNames(Character c) {
         List<String> names = new ArrayList<>();
         for (Ability a : c.getAbilities()) {
-            names.add(a.getName());
+            String entry = String.format("%s (EP: %d, Effect: %s)",
+                    a.getName(), a.getEpCost(), a.getDescription());
+            names.add(entry);
         }
         c.getInventory().getAllItems().stream()
                 .filter(i -> i instanceof SingleUseItem)
@@ -491,7 +500,12 @@ public final class BattleController {
     private String buildAbilityList(Character c) {
         StringBuilder sb = new StringBuilder();
         for (var a : c.getAbilities()) {
-            sb.append(a.getName()).append(" (").append(a.getEpCost()).append(" EP)").append("\n");
+            sb.append(a.getName())
+              .append(" (EP: ")
+              .append(a.getEpCost())
+              .append(", Effect: ")
+              .append(a.getDescription())
+              .append(")\n");
         }
         for (var item : c.getInventory().getAllItems()) {
             sb.append("Item: ").append(item.getName()).append("\n");

--- a/model/util/RandomCharacterGenerator.java
+++ b/model/util/RandomCharacterGenerator.java
@@ -6,6 +6,7 @@ import model.core.ClassType;
 import model.core.RaceType;
 import model.service.ClassService;
 import model.service.RaceService;
+import model.util.Constants;
 
 import java.util.List;
 import java.util.Random;
@@ -29,7 +30,8 @@ public final class RandomCharacterGenerator {
         ClassType clazz = classes[rng.nextInt(classes.length)];
 
         Character c = new Character(name, race, clazz);
-        List<Ability> abilities = classService.getRandomAbilitiesForClass(clazz, 3);
+        int abilityCount = Constants.NUM_ABILITIES_PER_CHAR + race.getExtraAbilitySlots();
+        List<Ability> abilities = classService.getRandomAbilitiesForClass(clazz, abilityCount);
         c.setAbilities(abilities);
         return c;
     }


### PR DESCRIPTION
## Summary
- allow RandomCharacterGenerator to create characters with either 3 or 4 abilities depending on race
- disable bot controls after launching a PvB battle
- show ability EP cost and description in battle dropdowns and lists
- parse ability names from dropdown selections when additional info is included

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6886dcdd719083289e546adbd3ad456d