### PR TITLE
Integrate magic items with battle actions

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -299,16 +299,44 @@ public final class BattleController {
     }
 
     private List<String> abilityNames(Character c) {
-        return c.getAbilities().stream().map(a -> a.getName()).toList();
+        List<String> names = new ArrayList<>();
+        for (var a : c.getAbilities()) {
+            names.add(a.getName() + " (EP: " + a.getEpCost() + ", Effect: " + a.getDescription() + ")");
+        }
+        var item = c.getInventory().getEquippedItem();
+        if (item != null) {
+            if (item instanceof SingleUseItem sui) {
+                names.add("Use Magic Item: " + sui.getName() + " (Single-Use, Effect: " + sui.getDescription() + ")");
+            } else {
+                names.add("Magic Item: " + item.getName() + " (Passive, Effect: " + item.getDescription() + ", Always Active)");
+            }
+        }
+        return names;
     }
 
     private String buildAbilityList(Character c) {
         StringBuilder sb = new StringBuilder();
         for (var a : c.getAbilities()) {
-            sb.append(a.getName()).append(" (").append(a.getEpCost()).append(" EP)").append("\n");
+            sb.append(a.getName())
+              .append(" (EP: ").append(a.getEpCost())
+              .append(", Effect: ").append(a.getDescription())
+              .append(")\n");
         }
-        if (c.getInventory().getEquippedItem() != null) {
-            sb.append("Equipped: ").append(c.getInventory().getEquippedItem().getName());
+        var item = c.getInventory().getEquippedItem();
+        if (item != null) {
+            if (item instanceof SingleUseItem sui) {
+                sb.append("Magic Item: ")
+                  .append(sui.getName())
+                  .append(" (Single-Use, Effect: ")
+                  .append(sui.getDescription())
+                  .append(")");
+            } else {
+                sb.append("Magic Item: ")
+                  .append(item.getName())
+                  .append(" (Passive, Effect: ")
+                  .append(item.getDescription())
+                  .append(", Always Active)");
+            }
         }
         return sb.toString();
     }

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -241,16 +241,30 @@ public final class SceneManager {
             battleView.setActionListener(e -> {
                 String cmd = e.getActionCommand();
                 if (BattleView.P1_USE.equals(cmd)) {
-                    String ability = battleView.getSelectedAbility(1);
-                    if (ability != null) {
-                        for (var ab : human.getAbilities()) {
-                            if (ab.getName().equals(ability)) {
+                    String selection = battleView.getSelectedAbility(1);
+                    if (selection != null) {
+                        var item = human.getInventory().getEquippedItem();
+                        if (item != null && selection.startsWith("Use Magic Item:")) {
+                            if (item instanceof model.item.SingleUseItem sui) {
                                 try {
-                                    battleController.submitMove(human, new model.battle.AbilityMove(ab));
+                                    battleController.submitMove(human, new model.battle.ItemMove(sui));
                                 } catch (GameException ex) {
                                     DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
                                 }
-                                break;
+                            }
+                        } else if (item != null && selection.startsWith("Magic Item:")) {
+                            DialogUtils.showInformationDialog("Magic Item", "Passive item effects are always active and do not require use.");
+                        } else {
+                            String abilityName = selection.split(" \\\(EP:")[0];
+                            for (var ab : human.getAbilities()) {
+                                if (ab.getName().equals(abilityName)) {
+                                    try {
+                                        battleController.submitMove(human, new model.battle.AbilityMove(ab));
+                                    } catch (GameException ex) {
+                                        DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                                    }
+                                    break;
+                                }
                             }
                         }
                     }

--- a/model/battle/ItemMove.java
+++ b/model/battle/ItemMove.java
@@ -4,6 +4,7 @@ import model.core.Character;
 import model.item.SingleUseItem;
 import model.util.GameException;
 import model.util.InputValidator;
+import model.battle.CombatLog;
 
 /**
  * Wraps the use of a {@link SingleUseItem} as a {@link Move} so it can
@@ -42,8 +43,7 @@ public final class ItemMove implements Move {
             throw new GameException("Item not found in inventory.");
         }
 
-        log.addEntry(user.getName() + " uses " + item.getName() + ".");
-        user.getInventory().removeItem(item);
-        // Actual item effects would be handled elsewhere
+        item.applyEffect(user, log);
+        user.getInventory().useSingleUseItem(item);
     }
 }

--- a/model/util/SimpleBot.java
+++ b/model/util/SimpleBot.java
@@ -1,9 +1,12 @@
 package model.util;
 
 import model.battle.AbilityMove;
+import model.battle.ItemMove;
 import model.battle.Move;
 import model.core.Ability;
 import model.core.Character;
+import model.item.SingleUseItem;
+import model.util.InputValidator;
 
 import java.util.List;
 import java.util.Random;
@@ -51,12 +54,18 @@ public final class SimpleBot implements AIMoveStrategy {
         InputValidator.requireNonNull(botCharacter, "botCharacter");
         InputValidator.requireNonNull(opponentCharacter, "opponentCharacter");
 
-        List<Ability> abilities = botCharacter.getAbilities();
-        if (abilities.isEmpty()) {
-            throw new GameException("Bot has no available abilities to use.");
+        List<Move> options = new java.util.ArrayList<>();
+        for (Ability ab : botCharacter.getAbilities()) {
+            options.add(new AbilityMove(ab));
         }
-
-        int index = random.nextInt(abilities.size());
-        return new AbilityMove(abilities.get(index));
+        var item = botCharacter.getInventory().getEquippedItem();
+        if (item instanceof SingleUseItem sui) {
+            options.add(new ItemMove(sui));
+        }
+        if (options.isEmpty()) {
+            throw new GameException("Bot has no available moves to use.");
+        }
+        int index = random.nextInt(options.size());
+        return options.get(index);
     }
 }


### PR DESCRIPTION
## Summary
- add combat log effect handling to `ItemMove`
- include equipped magic items when building battle dropdowns
- enable AI bot to randomly use single-use items
- support item selections in SceneManager battle handler

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6886df13dc1c83289a5ddc3a48e8ec27