### PR TITLE
Fix battle item/ability dropdown handling

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -300,45 +300,48 @@ public final class BattleController {
 
     private List<String> abilityNames(Character c) {
         List<String> names = new ArrayList<>();
+
+        // Abilities
         for (var a : c.getAbilities()) {
-            names.add(a.getName() + " (EP: " + a.getEpCost() + ", Effect: " + a.getDescription() + ")");
+            names.add(a.getName() + " (EP: " + a.getEpCost() + ")");
         }
-        var item = c.getInventory().getEquippedItem();
-        if (item != null) {
+
+        // Include all single-use items held by the character
+        for (var item : c.getInventory().getAllItems()) {
             if (item instanceof SingleUseItem sui) {
-                names.add("Use Magic Item: " + sui.getName() + " (Single-Use, Effect: " + sui.getDescription() + ")");
-            } else {
-                names.add("Magic Item: " + item.getName() + " (Passive, Effect: " + item.getDescription() + ", Always Active)");
+                names.add("Item: " + sui.getName());
             }
         }
+
         return names;
     }
 
     private String buildAbilityList(Character c) {
         StringBuilder sb = new StringBuilder();
+
+        // Abilities listed with EP cost only
         for (var a : c.getAbilities()) {
             sb.append(a.getName())
-              .append(" (EP: ").append(a.getEpCost())
-              .append(", Effect: ").append(a.getDescription())
+              .append(" (EP: ")
+              .append(a.getEpCost())
               .append(")\n");
         }
-        var item = c.getInventory().getEquippedItem();
-        if (item != null) {
-            if (item instanceof SingleUseItem sui) {
-                sb.append("Magic Item: ")
-                  .append(sui.getName())
-                  .append(" (Single-Use, Effect: ")
-                  .append(sui.getDescription())
-                  .append(")");
-            } else {
-                sb.append("Magic Item: ")
+
+        // List all magic items without descriptions
+        for (var item : c.getInventory().getAllItems()) {
+            if (item instanceof SingleUseItem) {
+                sb.append("Item: ")
                   .append(item.getName())
-                  .append(" (Passive, Effect: ")
-                  .append(item.getDescription())
-                  .append(", Always Active)");
+                  .append(" (Single-Use)\n");
+            } else {
+                sb.append("Item: ")
+                  .append(item.getName())
+                  .append(" (Passive)\n");
             }
         }
-        return sb.toString();
+
+        // Remove trailing newline if present
+        return sb.toString().trim();
     }
 
     private String formatStatus(Character c) {

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -242,19 +242,23 @@ public final class SceneManager {
                 if (BattleView.P1_USE.equals(cmd)) {
                     String selection = battleView.getSelectedAbility(1);
                     if (selection != null) {
-                        var item = human.getInventory().getEquippedItem();
-                        if (item != null && selection.startsWith("Use Magic Item:")) {
-                            if (item instanceof model.item.SingleUseItem sui) {
-                                try {
-                                    battleController.submitMove(human, new model.battle.ItemMove(sui));
-                                } catch (GameException ex) {
-                                    DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                        selection = selection.trim();
+
+                        if (selection.startsWith("Item: ")) {
+                            String itemName = selection.substring(6).trim();
+                            for (var mi : human.getInventory().getAllItems()) {
+                                if (mi instanceof model.item.SingleUseItem sui && mi.getName().equals(itemName)) {
+                                    try {
+                                        battleController.submitMove(human, new model.battle.ItemMove(sui));
+                                    } catch (GameException ex) {
+                                        DialogUtils.showErrorDialog("Battle Error", ex.getMessage());
+                                    }
+                                    break;
                                 }
                             }
-                        } else if (item != null && selection.startsWith("Magic Item:")) {
-                            DialogUtils.showInformationDialog("Magic Item", "Passive item effects are always active and do not require use.");
                         } else {
-                            String abilityName = selection.split(" \\\(EP:")[0];
+                            int idx = selection.indexOf(" (EP:");
+                            String abilityName = idx >= 0 ? selection.substring(0, idx).trim() : selection.trim();
                             for (var ab : human.getAbilities()) {
                                 if (ab.getName().equals(abilityName)) {
                                     try {


### PR DESCRIPTION
## Summary
- show EP cost only for abilities in dropdown and ability list
- list all single-use items with prefix "Item:" in dropdown and list
- update ability list without descriptions
- parse dropdown selections robustly in SceneManager

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886e465e05083288db52c05e12fb705