### PR TITLE
Add equipped item options to battle dropdown

### DIFF
--- a/model/util/SimpleBot.java
+++ b/model/util/SimpleBot.java
@@ -64,10 +64,9 @@ public final class SimpleBot implements AIMoveStrategy {
             }
         }
 
-        for (MagicItem item : botCharacter.getInventory().getAllItems()) {
-            if (item instanceof SingleUseItem su) {
-                options.add(new ItemMove(su));
-            }
+        MagicItem eq = botCharacter.getInventory().getEquippedItem();
+        if (eq instanceof SingleUseItem su) {
+            options.add(new ItemMove(su));
         }
 
         if (options.isEmpty()) {

--- a/model/util/SmartBot.java
+++ b/model/util/SmartBot.java
@@ -58,14 +58,13 @@ public final class SmartBot implements AIMoveStrategy {
             }
         }
 
-        for (MagicItem item : bot.getInventory().getAllItems()) {
-            if (item instanceof SingleUseItem su) {
-                switch (su.getEffectType()) {
-                    case HEAL_HP -> healingMoves.add(new ItemMove(su));
-                    case RESTORE_EP -> energyMoves.add(new ItemMove(su));
-                    case GRANT_IMMUNITY -> defensiveMoves.add(new ItemMove(su));
-                    default -> {}
-                }
+        MagicItem eq = bot.getInventory().getEquippedItem();
+        if (eq instanceof SingleUseItem su) {
+            switch (su.getEffectType()) {
+                case HEAL_HP -> healingMoves.add(new ItemMove(su));
+                case RESTORE_EP -> energyMoves.add(new ItemMove(su));
+                case GRANT_IMMUNITY -> defensiveMoves.add(new ItemMove(su));
+                default -> {}
             }
         }
 


### PR DESCRIPTION
## Summary
- allow selection of the equipped magic item during battle
- format dropdown entries and ability list with passive/single-use info
- bots now only consider equipped single-use items

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6886e9a159c48328bad9757e653b8b40