### PR TITLE
Add basic leveling system

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -338,9 +338,17 @@ public final class BattleController {
             if (gameManagerController != null) {
                 Player winPlayer = (winner == battleC1) ? player1 : player2;
                 if (winPlayer != null) {
-                    int xp = LevelingSystem.calculateXpGained(persistentWinner, persistentLoser);
-                    persistentWinner.addXp(xp);
-                    log.addEntry(persistentWinner.getName() + " gains " + xp + " XP.");
+                    persistentWinner.addExperience(50);
+                    persistentLoser.addExperience(20);
+                    log.addEntry(persistentWinner.getName() + " gains 50 XP.");
+                    log.addEntry(persistentLoser.getName() + " gains 20 XP.");
+                    persistentWinner.incrementBattlesWon();
+                    if (persistentWinner.canLevelUp()) {
+                        persistentWinner.levelUp();
+                        javax.swing.JOptionPane.showMessageDialog(null,
+                                persistentWinner.getName() + " reached Level " + persistentWinner.getLevel() + "!",
+                                "Level Up", javax.swing.JOptionPane.INFORMATION_MESSAGE);
+                    }
                     gameManagerController.handlePlayerWin(winPlayer, persistentWinner);
                 }
             }

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -418,11 +418,11 @@ public void actionPerformed(ActionEvent e) {
             }
 
             winner.incrementWins();
-            character.recordWin();
+            character.incrementBattlesWon();
             hallOfFameController.addWinForPlayer(winner);
             hallOfFameController.addWinForCharacter(character);
 
-            if (character.getWinCount() % Constants.WINS_PER_REWARD == 0) {
+            if (character.getBattlesWon() % Constants.WINS_PER_REWARD == 0) {
                 MagicItem reward = generateUniqueReward(character);
                 character.getInventory().addItem(reward);
                 javax.swing.JOptionPane.showMessageDialog(null,

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -173,9 +173,9 @@ public class PlayerCharacterManagementController {
             ev.setAbilityOptions(i, opts);
         }
 
-        boolean isGnome = c.getRaceType() == model.core.RaceType.GNOME;
-        ev.setAbility4Visible(isGnome);
-        if (isGnome) {
+        boolean allowFour = c.getAbilitySlots() > 3;
+        ev.setAbility4Visible(allowFour);
+        if (allowFour) {
             ev.setAbilityOptions(4, opts);
         }
 
@@ -183,7 +183,7 @@ public class PlayerCharacterManagementController {
         for (int i = 0; i < Math.min(current.size(), 3); i++) {
             ev.setSelectedAbility(i + 1, current.get(i).getName());
         }
-        if (isGnome && current.size() >= 4) {
+        if (allowFour && current.size() >= 4) {
             ev.setSelectedAbility(4, current.get(3).getName());
         }
 

--- a/src/test/java/model/core/LevelingTest.java
+++ b/src/test/java/model/core/LevelingTest.java
@@ -1,0 +1,21 @@
+package model.core;
+
+import model.util.GameException;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests the leveling and XP progression. */
+public class LevelingTest {
+
+    @Test
+    public void testLevelUpAfterMilestone() throws GameException {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR, java.util.List.of());
+        for (int i = 0; i < 5; i++) c.incrementBattlesWon();
+        c.addExperience(50);
+        assertTrue(c.canLevelUp());
+        c.levelUp();
+        assertEquals(2, c.getLevel());
+        assertEquals(4, c.getAbilitySlots());
+        assertEquals(10, c.getNextLevelMilestone());
+    }
+}

--- a/src/test/java/persistence/LevelingPersistenceTest.java
+++ b/src/test/java/persistence/LevelingPersistenceTest.java
@@ -1,0 +1,38 @@
+package persistence;
+
+import model.core.*;
+import model.util.GameException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Ensures new leveling fields persist. */
+public class LevelingPersistenceTest {
+
+    @AfterEach
+    public void cleanup() {
+        new File(Constants.SAVE_FILE_PATH).delete();
+    }
+
+    @Test
+    public void testSaveLoadLevelFields() throws GameException {
+        Player p = new Player("P1");
+        Character c = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        for (int i = 0; i < 5; i++) c.incrementBattlesWon();
+        c.addExperience(50);
+        if (c.canLevelUp()) c.levelUp();
+        p.addCharacter(c);
+        GameData data = new GameData(List.of(p), List.of());
+        SaveLoadService.saveGame(data);
+        GameData loaded = SaveLoadService.loadGame();
+        Character loadedChar = loaded.getAllPlayers().get(0).getCharacters().get(0);
+        assertEquals(c.getLevel(), loadedChar.getLevel());
+        assertEquals(c.getExperience(), loadedChar.getExperience());
+        assertEquals(c.getBattlesWon(), loadedChar.getBattlesWon());
+        assertEquals(c.getNextLevelMilestone(), loadedChar.getNextLevelMilestone());
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Character` with XP, battles won and milestone fields
- add leveling methods and ability slot unlocking
- update battle flow to grant XP, wins and level up
- persist wins for item rewards using new API
- adapt character editing UI logic for dynamic ability slots
- add unit tests for leveling and persistence

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6886fd7bc2f48328b2a83d42a226efae