### PR TITLE
Implement unlocked ability slot tracking

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -535,7 +535,9 @@ public final class BattleController {
     private List<String> abilityNames(Character c) {
         List<String> names = new ArrayList<>();
 
-        for (Ability a : c.getAbilities()) {
+        int limit = Math.min(c.getUnlockedAbilitySlots(), c.getAbilities().size());
+        for (int i = 0; i < limit; i++) {
+            Ability a = c.getAbilities().get(i);
             String entry = String.format(
                     "%s (EP: %d, Effect: %s)",
                     a.getName(), a.getEpCost(), a.getDescription());
@@ -563,7 +565,9 @@ public final class BattleController {
     private String buildAbilityList(Character c) {
         StringBuilder sb = new StringBuilder();
 
-        for (Ability a : c.getAbilities()) {
+        int limit = Math.min(c.getUnlockedAbilitySlots(), c.getAbilities().size());
+        for (int i = 0; i < limit; i++) {
+            Ability a = c.getAbilities().get(i);
             sb.append(a.getName())
               .append(" (EP: ")
               .append(a.getEpCost())

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -173,7 +173,7 @@ public class PlayerCharacterManagementController {
             ev.setAbilityOptions(i, opts);
         }
 
-        boolean allowFour = c.getAbilitySlots() > 3;
+        boolean allowFour = c.getUnlockedAbilitySlots() > 3;
         ev.setAbility4Visible(allowFour);
         if (allowFour) {
             ev.setAbilityOptions(4, opts);
@@ -243,7 +243,7 @@ public class PlayerCharacterManagementController {
                 }
             }
 
-            int expected = 3 + (c.getRaceType() == model.core.RaceType.GNOME ? 1 : 0);
+            int expected = Math.min(c.getUnlockedAbilitySlots(), 4);
             if (abilityNames.length != expected) {
                 ev.showErrorMessage("Incorrect number of abilities selected.");
                 return;

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -55,6 +55,7 @@ public class Character implements Serializable {
     private int battlesWon;
     private int nextLevelMilestone;
     private int abilitySlots;
+    private int unlockedAbilitySlots;
 
     // --- Temporary Battle State ---
     private boolean isStunned;
@@ -84,6 +85,7 @@ public class Character implements Serializable {
         this.battlesWon = other.battlesWon;
         this.nextLevelMilestone = other.nextLevelMilestone;
         this.abilitySlots = other.abilitySlots;
+        this.unlockedAbilitySlots = other.unlockedAbilitySlots;
 
         this.isStunned = false;
     }
@@ -128,6 +130,9 @@ public class Character implements Serializable {
         this.isStunned = false;
 
         initializeStats();
+        if (!this.abilities.isEmpty()) {
+            this.unlockedAbilitySlots = Math.min(this.abilities.size(), this.abilitySlots);
+        }
     }
 
     /**
@@ -156,6 +161,7 @@ public class Character implements Serializable {
         this.battlesWon = 0;
         this.nextLevelMilestone = 5;
         this.abilitySlots = Constants.NUM_ABILITIES_PER_CHAR + race.getExtraAbilitySlots();
+        this.unlockedAbilitySlots = this.abilitySlots;
     }
 
     // --- Getters for Core Attributes ---
@@ -191,6 +197,7 @@ public class Character implements Serializable {
     public int getBattlesWon() { return battlesWon; }
     public int getNextLevelMilestone() { return nextLevelMilestone; }
     public int getAbilitySlots() { return abilitySlots; }
+    public int getUnlockedAbilitySlots() { return unlockedAbilitySlots; }
 
     // --- Combat State Management ---
 
@@ -302,6 +309,7 @@ public class Character implements Serializable {
     public void unlockAbilitySlot() {
         if (level == 2 || level == 4) {
             this.abilitySlots++;
+            this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + 1, this.abilitySlots);
         }
     }
 
@@ -463,6 +471,9 @@ public class Character implements Serializable {
         }
         if (abilitySlots == 0) {
             abilitySlots = Constants.NUM_ABILITIES_PER_CHAR + race.getExtraAbilitySlots();
+        }
+        if (unlockedAbilitySlots == 0) {
+            unlockedAbilitySlots = abilitySlots;
         }
     }
 }

--- a/src/test/java/controller/AbilityDropdownTest.java
+++ b/src/test/java/controller/AbilityDropdownTest.java
@@ -1,0 +1,59 @@
+package controller;
+
+import model.core.Character;
+import model.core.ClassType;
+import model.core.RaceType;
+import model.core.Ability;
+import model.service.ClassService;
+import model.util.GameException;
+import org.junit.jupiter.api.Test;
+import view.BattleView;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AbilityDropdownTest {
+
+    private static class CaptureView extends BattleView {
+        List<String> p1Options;
+        List<String> p2Options;
+        CaptureView() { super(1); }
+        @Override public void displayBattleStart(Character c1, Character c2) {}
+        @Override public void displayTurnResults(model.battle.CombatLog log) {}
+        @Override public void displayBattleEnd(Character winner) {}
+        @Override
+        public void updateAbilityDropdown(int playerID, java.util.List<String> options) {
+            super.updateAbilityDropdown(playerID, options);
+            if(playerID==1) p1Options = new ArrayList<>(options);
+            else p2Options = new ArrayList<>(options);
+        }
+    }
+
+    @Test
+    public void testDropdownRespectsUnlockedSlots() throws Exception {
+        List<Ability> all = ClassService.INSTANCE.getAvailableAbilities(ClassType.WARRIOR);
+        Character c1 = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        // unlock slots to allow 5 abilities
+        c1.setLevel(4);
+        c1.unlockAbilitySlot();
+        c1.unlockAbilitySlot();
+        c1.setAbilities(all);
+
+        // lock to 3 slots via reflection
+        Field f = Character.class.getDeclaredField("unlockedAbilitySlots");
+        f.setAccessible(true);
+        f.setInt(c1, 3);
+
+        Character c2 = new Character("B", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        c2.setAbilities(all.subList(0,3));
+
+        CaptureView view = new CaptureView();
+        BattleController bc = new BattleController(view);
+        bc.startBattle(c1, c2);
+
+        assertEquals(3, view.p1Options.size());
+    }
+}

--- a/src/test/java/model/core/LevelingTest.java
+++ b/src/test/java/model/core/LevelingTest.java
@@ -16,6 +16,7 @@ public class LevelingTest {
         c.levelUp();
         assertEquals(2, c.getLevel());
         assertEquals(4, c.getAbilitySlots());
+        assertEquals(4, c.getUnlockedAbilitySlots());
         assertEquals(10, c.getNextLevelMilestone());
     }
 }

--- a/src/test/java/persistence/LevelingPersistenceTest.java
+++ b/src/test/java/persistence/LevelingPersistenceTest.java
@@ -34,5 +34,6 @@ public class LevelingPersistenceTest {
         assertEquals(c.getExperience(), loadedChar.getExperience());
         assertEquals(c.getBattlesWon(), loadedChar.getBattlesWon());
         assertEquals(c.getNextLevelMilestone(), loadedChar.getNextLevelMilestone());
+        assertEquals(c.getUnlockedAbilitySlots(), loadedChar.getUnlockedAbilitySlots());
     }
 }

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -468,6 +468,7 @@ public class BattleView extends JFrame {
         for (String option : options) {
             combo.addItem(option);
         }
+        combo.setMaximumRowCount(options.size());
     }
 
 


### PR DESCRIPTION
## Summary
- add `unlockedAbilitySlots` field to `Character`
- only show unlocked abilities in battle dropdowns
- expose ability slot count in UI and update dropdown row count
- adjust player management to use unlocked slots
- persist unlocked slot count and update tests
- test dropdown sizing with a new `AbilityDropdownTest`

## Testing
- `mvn test` *(fails: Could not resolve Maven plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688704331bf08328833cbceec30f00b5