### PR TITLE
Implement dynamic ability slot expansion across views

### DIFF
--- a/controller/CharacterManualCreationController.java
+++ b/controller/CharacterManualCreationController.java
@@ -11,6 +11,7 @@ import model.core.Player;
 import model.core.RaceType;
 import model.service.ClassService;
 import model.service.RaceService;
+import model.util.Constants;
 import model.util.GameException;
 import model.util.InputValidator;
 import view.CharacterManualCreationView;
@@ -78,10 +79,10 @@ public final class CharacterManualCreationController {
     }
 
     private void clearAbilityOptions() {
-        view.setAbilityOptions(1, new String[0]);
-        view.setAbilityOptions(2, new String[0]);
-        view.setAbilityOptions(3, new String[0]);
-        view.setAbilityOptions(4, new String[0]);
+        int count = view.getAbilityCount();
+        for (int i = 1; i <= count; i++) {
+            view.setAbilityOptions(i, new String[0]);
+        }
     }
 
     // --- UI Event Binding ---
@@ -113,7 +114,7 @@ public final class CharacterManualCreationController {
 
             RaceType race = RaceType.valueOf(raceStr);
 
-            int expectedAbilities = 3 + (race == RaceType.GNOME ? 1 : 0);
+            int expectedAbilities = view.getAbilityCount();
 
             long count = Arrays.stream(selectedAbilityNames)
                     .filter(a -> a != null && !a.isBlank()).count();
@@ -170,9 +171,10 @@ public final class CharacterManualCreationController {
         String raceStr = view.getSelectedRace();
         if (raceStr != null && !raceStr.isBlank()) {
             RaceType race = RaceType.valueOf(raceStr);
-            view.setAbility4Visible(race == RaceType.GNOME);
+            int slots = Constants.NUM_ABILITIES_PER_CHAR + race.getExtraAbilitySlots();
+            view.setAbilityCount(slots);
         } else {
-            view.setAbility4Visible(false);
+            view.setAbilityCount(Constants.NUM_ABILITIES_PER_CHAR);
         }
         refreshAbilityOptions();
     }
@@ -188,13 +190,9 @@ public final class CharacterManualCreationController {
             List<String> abilityNames = classService.getAvailableAbilities(classType)
                     .stream().map(Ability::getName).collect(Collectors.toList());
             String[] options = abilityNames.toArray(new String[0]);
-            view.setAbilityOptions(1, options);
-            view.setAbilityOptions(2, options);
-            view.setAbilityOptions(3, options);
-
-            String raceStr = view.getSelectedRace();
-            if (raceStr != null && !raceStr.isBlank() && RaceType.valueOf(raceStr) == RaceType.GNOME) {
-                view.setAbilityOptions(4, options);
+            int count = view.getAbilityCount();
+            for (int i = 1; i <= count; i++) {
+                view.setAbilityOptions(i, options);
             }
         } catch (Exception e) {
             clearAbilityOptions();

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -122,8 +122,20 @@ public class PlayerCharacterManagementController {
                     return;
                 }
                 Character c = player.getCharacter(name).orElse(null);
-                String details = (c == null) ? "Character not found." : c.toString() + "\nAbilities:\n" +
-                        c.getAbilities().stream().map(Ability::getName).collect(Collectors.joining("\n"));
+                String details;
+                if (c == null) {
+                    details = "Character not found.";
+                } else {
+                    java.util.List<String> abilityNames = new java.util.ArrayList<>();
+                    for (int i = 0; i < c.getAbilitySlots(); i++) {
+                        if (i < c.getAbilities().size()) {
+                            abilityNames.add(c.getAbilities().get(i).getName());
+                        } else {
+                            abilityNames.add("Empty Slot");
+                        }
+                    }
+                    details = c.toString() + "\nAbilities:\n" + String.join("\n", abilityNames);
+                }
                 specView.updateCharacterDetails(details);
             }
         });
@@ -169,22 +181,15 @@ public class PlayerCharacterManagementController {
             abilityNames = List.of();
         }
         String[] opts = abilityNames.toArray(new String[0]);
-        for (int i = 1; i <= 3; i++) {
+        int slots = c.getAbilitySlots();
+        ev.setAbilityCount(slots);
+        for (int i = 1; i <= slots; i++) {
             ev.setAbilityOptions(i, opts);
         }
 
-        boolean allowFour = c.getUnlockedAbilitySlots() > 3;
-        ev.setAbility4Visible(allowFour);
-        if (allowFour) {
-            ev.setAbilityOptions(4, opts);
-        }
-
         List<Ability> current = c.getAbilities();
-        for (int i = 0; i < Math.min(current.size(), 3); i++) {
+        for (int i = 0; i < Math.min(current.size(), slots); i++) {
             ev.setSelectedAbility(i + 1, current.get(i).getName());
-        }
-        if (allowFour && current.size() >= 4) {
-            ev.setSelectedAbility(4, current.get(3).getName());
         }
 
         List<MagicItem> items = c.getInventory().getAllItems();
@@ -243,7 +248,7 @@ public class PlayerCharacterManagementController {
                 }
             }
 
-            int expected = Math.min(c.getUnlockedAbilitySlots(), 4);
+            int expected = ev.getAbilityCount();
             if (abilityNames.length != expected) {
                 ev.showErrorMessage("Incorrect number of abilities selected.");
                 return;

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -199,6 +199,18 @@ public class Character implements Serializable {
     public int getAbilitySlots() { return abilitySlots; }
     public int getUnlockedAbilitySlots() { return unlockedAbilitySlots; }
 
+    /**
+     * Increases the total available ability slots for this character.
+     * The unlocked slots are also increased but never exceed the total.
+     *
+     * @param n number of slots to add (ignored if non-positive)
+     */
+    public void increaseAbilitySlots(int n) {
+        if (n <= 0) return;
+        this.abilitySlots += n;
+        this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + n, this.abilitySlots);
+    }
+
     // --- Combat State Management ---
 
     /**
@@ -308,8 +320,7 @@ public class Character implements Serializable {
     /** Unlocks an additional ability slot at specific level thresholds. */
     public void unlockAbilitySlot() {
         if (level == 2 || level == 4) {
-            this.abilitySlots++;
-            this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + 1, this.abilitySlots);
+            increaseAbilitySlots(1);
         }
     }
 

--- a/view/CharacterEditView.java
+++ b/view/CharacterEditView.java
@@ -38,15 +38,8 @@ public class CharacterEditView extends JFrame {
     public static final String RETURN = "Return";
 
     private final JComboBox<String> dropdownCharacter = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility1  = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility2  = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility3  = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility4  = new JComboBox<>();
-
-    @SuppressWarnings("unchecked")
-    private final JComboBox<String>[] abilityDropdowns = new JComboBox[] {
-            dropdownAbility1, dropdownAbility2, dropdownAbility3, dropdownAbility4
-    };
+    // Ability dropdowns are created dynamically
+    private final java.util.List<JComboBox<String>> abilityDropdowns = new ArrayList<>();
     private final JComboBox<String> dropdownMagicItem = new JComboBox<>();
 
     private JPanel abilitiesPanel;
@@ -129,10 +122,7 @@ public class CharacterEditView extends JFrame {
         abilitiesPanel.setOpaque(false);
         abilitiesPanel.setLayout(new BoxLayout(abilitiesPanel, BoxLayout.Y_AXIS));
 
-        for (int i = 0; i < abilityDropdowns.length; i++) {
-            abilityPanels.add(createDropdownPanel("Select Ability " + (i + 1), abilityDropdowns[i]));
-        }
-
+        // initialise default dropdowns
         setAbilityCount(abilityCount);
 
         centerPanel.add(abilitiesPanel);
@@ -184,10 +174,9 @@ public class CharacterEditView extends JFrame {
         btnEdit.addActionListener(listener);
         btnReturn.addActionListener(listener);
         dropdownCharacter.addActionListener(listener);
-        dropdownAbility1.addActionListener(listener);
-        dropdownAbility2.addActionListener(listener);
-        dropdownAbility3.addActionListener(listener);
-        dropdownAbility4.addActionListener(listener);
+        for (JComboBox<String> dd : abilityDropdowns) {
+            dd.addActionListener(listener);
+        }
         dropdownMagicItem.addActionListener(listener);
     }
 
@@ -197,10 +186,10 @@ public class CharacterEditView extends JFrame {
     }
 
     public void setAbilityOptions(int slot, String[] options) {
-        if (slot < 1 || slot > abilityDropdowns.length) {
+        if (slot < 1 || slot > abilityDropdowns.size()) {
             throw new IllegalArgumentException("Invalid slot: " + slot);
         }
-        JComboBox<String> target = abilityDropdowns[slot - 1];
+        JComboBox<String> target = abilityDropdowns.get(slot - 1);
         target.removeAllItems();
         for (String option : options) {
             target.addItem(option);
@@ -213,10 +202,10 @@ public class CharacterEditView extends JFrame {
     }
 
     public void setSelectedAbility(int slot, String abilityName) {
-        if (slot < 1 || slot > abilityDropdowns.length) {
+        if (slot < 1 || slot > abilityDropdowns.size()) {
             throw new IllegalArgumentException("Invalid slot: " + slot);
         }
-        abilityDropdowns[slot - 1].setSelectedItem(abilityName);
+        abilityDropdowns.get(slot - 1).setSelectedItem(abilityName);
     }
 
     public void setSelectedMagicItem(String itemName) {
@@ -258,31 +247,38 @@ public class CharacterEditView extends JFrame {
     public String[] getSelectedAbilities() {
         String[] selected = new String[abilityCount];
         for (int i = 0; i < abilityCount; i++) {
-            selected[i] = (String) abilityDropdowns[i].getSelectedItem();
+            selected[i] = (String) abilityDropdowns.get(i).getSelectedItem();
         }
         return selected;
     }
 
     public String getSelectedAbility(int slot) {
-        if (slot < 1 || slot > abilityDropdowns.length) {
+        if (slot < 1 || slot > abilityDropdowns.size()) {
             throw new IllegalArgumentException("Invalid slot: " + slot);
         }
-        return (String) abilityDropdowns[slot - 1].getSelectedItem();
+        return (String) abilityDropdowns.get(slot - 1).getSelectedItem();
     }
 
     public String getSelectedMagicItem() {
         return (String) dropdownMagicItem.getSelectedItem();
     }
 
-    public void setAbility4Visible(boolean visible) {
-        setAbilityCount(visible ? 4 : 3);
-    }
-
+    /**
+     * Adjusts the number of ability dropdowns shown.
+     */
     public void setAbilityCount(int count) {
-        if (count < 3 || count > 4) {
-            throw new IllegalArgumentException("Ability count must be 3 or 4");
+        if (count < 1) {
+            throw new IllegalArgumentException("Ability count must be positive");
         }
         abilityCount = count;
+
+        while (abilityDropdowns.size() < count) {
+            int idx = abilityDropdowns.size();
+            JComboBox<String> dd = new JComboBox<>();
+            abilityDropdowns.add(dd);
+            abilityPanels.add(createDropdownPanel("Select Ability " + (idx + 1), dd));
+        }
+
         abilitiesPanel.removeAll();
         abilitiesPanel.add(Box.createVerticalStrut(20));
         for (int i = 0; i < abilityCount; i++) {
@@ -291,5 +287,10 @@ public class CharacterEditView extends JFrame {
         }
         abilitiesPanel.revalidate();
         abilitiesPanel.repaint();
+    }
+
+    /** Returns current number of ability dropdowns. */
+    public int getAbilityCount() {
+        return abilityCount;
     }
 }

--- a/view/CharacterManualCreationView.java
+++ b/view/CharacterManualCreationView.java
@@ -28,10 +28,8 @@ public class CharacterManualCreationView extends JFrame {
     private final RoundedTextField charNameField;
     private final JComboBox<String> dropdownRace = new JComboBox<>();
     private final JComboBox<String> dropdownClass = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility1 = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility2 = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility3 = new JComboBox<>();
-    private final JComboBox<String> dropdownAbility4 = new JComboBox<>();
+    // Ability dropdowns are created dynamically based on slot count
+    private final java.util.List<JComboBox<String>> abilityDropdowns = new ArrayList<>();
     private final JButton btnCreate;
     private final JButton btnReturn;
 
@@ -117,14 +115,8 @@ public class CharacterManualCreationView extends JFrame {
         abilitiesPanel.setOpaque(false);
         abilitiesPanel.setLayout(new BoxLayout(abilitiesPanel, BoxLayout.Y_AXIS));
 
-        for (int i = 0; i < 4; i++) {
-            abilityPanels.add(createDropdownPanel("Select Ability " + (i + 1), switch (i) {
-                case 0 -> dropdownAbility1;
-                case 1 -> dropdownAbility2;
-                case 2 -> dropdownAbility3;
-                default -> dropdownAbility4;
-            }));
-        }
+        // initialise default number of ability dropdowns
+        setAbilityCount(abilityCount);
 
         setAbilityCount(abilityCount);
         centerPanel.add(abilitiesPanel);
@@ -202,13 +194,10 @@ public class CharacterManualCreationView extends JFrame {
     }
 
     public void setAbilityOptions(int abilitySlot, String[] abilities) {
-        JComboBox<String> target = switch (abilitySlot) {
-            case 1 -> dropdownAbility1;
-            case 2 -> dropdownAbility2;
-            case 3 -> dropdownAbility3;
-            case 4 -> dropdownAbility4;
-            default -> throw new IllegalArgumentException("Invalid ability slot: " + abilitySlot);
-        };
+        if (abilitySlot < 1 || abilitySlot > abilityDropdowns.size()) {
+            throw new IllegalArgumentException("Invalid ability slot: " + abilitySlot);
+        }
+        JComboBox<String> target = abilityDropdowns.get(abilitySlot - 1);
         target.removeAllItems();
         for (String a : abilities) target.addItem(a);
     }
@@ -217,10 +206,9 @@ public class CharacterManualCreationView extends JFrame {
         charNameField.setText("");
         dropdownRace.setSelectedIndex(-1);
         dropdownClass.setSelectedIndex(-1);
-        dropdownAbility1.setSelectedIndex(-1);
-        dropdownAbility2.setSelectedIndex(-1);
-        dropdownAbility3.setSelectedIndex(-1);
-        dropdownAbility4.setSelectedIndex(-1);
+        for (JComboBox<String> dd : abilityDropdowns) {
+            dd.setSelectedIndex(-1);
+        }
     }
 
     // --- Getters for Controller to retrieve input ---
@@ -233,11 +221,8 @@ public class CharacterManualCreationView extends JFrame {
 
     public String[] getSelectedAbilities() {
         String[] selected = new String[abilityCount];
-        JComboBox<String>[] dropdowns = new JComboBox[] {
-                dropdownAbility1, dropdownAbility2, dropdownAbility3, dropdownAbility4
-        };
         for (int i = 0; i < abilityCount; i++) {
-            selected[i] = (String) dropdowns[i].getSelectedItem();
+            selected[i] = (String) abilityDropdowns.get(i).getSelectedItem();
         }
         return selected;
     }
@@ -264,20 +249,23 @@ public class CharacterManualCreationView extends JFrame {
     // Optional: expose dropdowns for advanced use
     public JComboBox<String> getRaceDropdown()   { return dropdownRace; }
     public JComboBox<String> getClassDropdown()  { return dropdownClass; }
-    public JComboBox<String> getAbility1Dropdown() { return dropdownAbility1; }
-    public JComboBox<String> getAbility2Dropdown() { return dropdownAbility2; }
-    public JComboBox<String> getAbility3Dropdown() { return dropdownAbility3; }
-    public JComboBox<String> getAbility4Dropdown() { return dropdownAbility4; }
 
-    public void setAbility4Visible(boolean visible) {
-        setAbilityCount(visible ? 4 : 3);
-    }
-
+    /**
+     * Sets how many ability selection dropdowns are visible.
+     */
     public void setAbilityCount(int count) {
-        if (count < 3 || count > 4) {
-            throw new IllegalArgumentException("Ability count must be 3 or 4");
+        if (count < 1) {
+            throw new IllegalArgumentException("Ability count must be positive");
         }
         abilityCount = count;
+
+        while (abilityDropdowns.size() < count) {
+            int idx = abilityDropdowns.size();
+            JComboBox<String> dd = new JComboBox<>();
+            abilityDropdowns.add(dd);
+            abilityPanels.add(createDropdownPanel("Select Ability " + (idx + 1), dd));
+        }
+
         abilitiesPanel.removeAll();
         for (int i = 0; i < abilityCount; i++) {
             if (i > 0) abilitiesPanel.add(Box.createVerticalStrut(10));
@@ -285,6 +273,11 @@ public class CharacterManualCreationView extends JFrame {
         }
         abilitiesPanel.revalidate();
         abilitiesPanel.repaint();
+    }
+
+    /** Returns how many ability dropdowns are currently visible. */
+    public int getAbilityCount() {
+        return abilityCount;
     }
 
     // Controller setter (optional, for reference by controller)


### PR DESCRIPTION
## Summary
- add new `increaseAbilitySlots` method for `Character`
- adapt manual character creation to display dynamic ability dropdowns
- update character editing view to support arbitrary ability slots
- update controllers for manual creation and editing to respect variable slot counts
- show empty ability slots in character detail view

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688719d021dc8328b861914e13864c0c