### PR TITLE
Implement dynamic ability slot count

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -553,7 +553,7 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
     private List<String> abilityNames(Character c) {
         List<String> names = new ArrayList<>();
 
-        int limit = Math.min(c.getUnlockedAbilitySlots(), c.getAbilities().size());
+        int limit = Math.min(c.getAbilitySlotCount(), c.getAbilities().size());
         for (int i = 0; i < limit; i++) {
             Ability a = c.getAbilities().get(i);
             String entry = String.format(
@@ -583,7 +583,7 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
     private String buildAbilityList(Character c) {
         StringBuilder sb = new StringBuilder();
 
-        int limit = Math.min(c.getUnlockedAbilitySlots(), c.getAbilities().size());
+        int limit = Math.min(c.getAbilitySlotCount(), c.getAbilities().size());
         for (int i = 0; i < limit; i++) {
             Ability a = c.getAbilities().get(i);
             sb.append(a.getName())

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -173,7 +173,7 @@ public class PlayerCharacterManagementController {
             ev.setAbilityOptions(i, opts);
         }
 
-        boolean allowFour = c.getUnlockedAbilitySlots() > 3;
+        boolean allowFour = c.getAbilitySlotCount() > 3;
         ev.setAbility4Visible(allowFour);
         if (allowFour) {
             ev.setAbilityOptions(4, opts);
@@ -243,7 +243,7 @@ public class PlayerCharacterManagementController {
                 }
             }
 
-            int expected = Math.min(c.getUnlockedAbilitySlots(), 4);
+        int expected = Math.min(c.getAbilitySlotCount(), 4);
             if (abilityNames.length != expected) {
                 ev.showErrorMessage("Incorrect number of abilities selected.");
                 return;

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -56,6 +56,8 @@ public class Character implements Serializable {
     private int nextLevelMilestone;
     private int abilitySlots;
     private int unlockedAbilitySlots;
+    /** Tracks how many ability slots are currently available. */
+    private int abilitySlotCount;
 
     // --- Temporary Battle State ---
     private boolean isStunned;
@@ -86,6 +88,7 @@ public class Character implements Serializable {
         this.nextLevelMilestone = other.nextLevelMilestone;
         this.abilitySlots = other.abilitySlots;
         this.unlockedAbilitySlots = other.unlockedAbilitySlots;
+        this.abilitySlotCount = other.abilitySlotCount;
 
         this.isStunned = false;
     }
@@ -133,6 +136,7 @@ public class Character implements Serializable {
         if (!this.abilities.isEmpty()) {
             this.unlockedAbilitySlots = Math.min(this.abilities.size(), this.abilitySlots);
         }
+        this.abilitySlotCount = this.unlockedAbilitySlots;
     }
 
     /**
@@ -162,6 +166,7 @@ public class Character implements Serializable {
         this.nextLevelMilestone = 5;
         this.abilitySlots = Constants.NUM_ABILITIES_PER_CHAR + race.getExtraAbilitySlots();
         this.unlockedAbilitySlots = this.abilitySlots;
+        this.abilitySlotCount = this.abilitySlots;
     }
 
     // --- Getters for Core Attributes ---
@@ -198,6 +203,7 @@ public class Character implements Serializable {
     public int getNextLevelMilestone() { return nextLevelMilestone; }
     public int getAbilitySlots() { return abilitySlots; }
     public int getUnlockedAbilitySlots() { return unlockedAbilitySlots; }
+    public int getAbilitySlotCount() { return abilitySlotCount; }
 
     // --- Combat State Management ---
 
@@ -310,6 +316,7 @@ public class Character implements Serializable {
         if (level == 2 || level == 4) {
             this.abilitySlots++;
             this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + 1, this.abilitySlots);
+            this.abilitySlotCount = this.unlockedAbilitySlots;
         }
     }
 
@@ -356,8 +363,8 @@ public class Character implements Serializable {
      */
     public void setAbilities(List<Ability> newAbilities) {
         InputValidator.requireNonNull(newAbilities, "New abilities list");
-        if (newAbilities.size() > abilitySlots) {
-            throw new IllegalArgumentException("A character can equip at most " + abilitySlots + " abilities.");
+        if (newAbilities.size() > abilitySlotCount) {
+            throw new IllegalArgumentException("A character can equip at most " + abilitySlotCount + " abilities.");
         }
         this.abilities.clear();
         this.abilities.addAll(newAbilities);
@@ -474,6 +481,9 @@ public class Character implements Serializable {
         }
         if (unlockedAbilitySlots == 0) {
             unlockedAbilitySlots = abilitySlots;
+        }
+        if (abilitySlotCount == 0) {
+            abilitySlotCount = unlockedAbilitySlots;
         }
     }
 }

--- a/src/test/java/controller/AbilityDropdownTest.java
+++ b/src/test/java/controller/AbilityDropdownTest.java
@@ -43,7 +43,7 @@ public class AbilityDropdownTest {
         c1.setAbilities(all);
 
         // lock to 3 slots via reflection
-        Field f = Character.class.getDeclaredField("unlockedAbilitySlots");
+        Field f = Character.class.getDeclaredField("abilitySlotCount");
         f.setAccessible(true);
         f.setInt(c1, 3);
 

--- a/src/test/java/model/core/LevelingTest.java
+++ b/src/test/java/model/core/LevelingTest.java
@@ -17,6 +17,7 @@ public class LevelingTest {
         assertEquals(2, c.getLevel());
         assertEquals(4, c.getAbilitySlots());
         assertEquals(4, c.getUnlockedAbilitySlots());
+        assertEquals(4, c.getAbilitySlotCount());
         assertEquals(10, c.getNextLevelMilestone());
     }
 }

--- a/src/test/java/persistence/LevelingPersistenceTest.java
+++ b/src/test/java/persistence/LevelingPersistenceTest.java
@@ -35,5 +35,6 @@ public class LevelingPersistenceTest {
         assertEquals(c.getBattlesWon(), loadedChar.getBattlesWon());
         assertEquals(c.getNextLevelMilestone(), loadedChar.getNextLevelMilestone());
         assertEquals(c.getUnlockedAbilitySlots(), loadedChar.getUnlockedAbilitySlots());
+        assertEquals(c.getAbilitySlotCount(), loadedChar.getAbilitySlotCount());
     }
 }


### PR DESCRIPTION
## Summary
- add abilitySlotCount tracking to `Character`
- use abilitySlotCount in battle and character management controllers
- update tests for new getter and persistence

## Testing
- `mvn -q test` *(fails: could not resolve maven dependencies)*
- `javac $(find . -name '*.java')` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68872d728c3483288e681c1ea2138049