### PR TITLE
Refactor magic items with rarity enum

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -353,9 +353,7 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
                         log.addEntry(persistentWinner.getName() + " is awarded a magic item: " + reward.getName());
                         javax.swing.JOptionPane.showMessageDialog(
                                 null,
-                                persistentWinner.getName() + " has been awarded a magic item!\n\n" +
-                                        reward.getName() + " (" + reward.getRarity() + ")\n" +
-                                        reward.getDescription(),
+                                buildAwardMessage(reward),
                                 "Magic Item Awarded!",
                                 javax.swing.JOptionPane.INFORMATION_MESSAGE
                         );
@@ -613,5 +611,28 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
             return base + " | " + statuses;
         }
         return base;
+    }
+
+    private String buildAwardMessage(MagicItem item) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Congratulations! You received a ")
+          .append(item.getRarityType()).append(' ')
+          .append(item.getItemType()).append(" Item: ")
+          .append(item.getName()).append('!');
+        if (item instanceof SingleUseItem su) {
+            sb.append("\nEffect: ").append(describeEffect(su));
+        } else {
+            sb.append("\nEffect: ").append(item.getDescription());
+        }
+        return sb.toString();
+    }
+
+    private String describeEffect(SingleUseItem item) {
+        return switch (item.getEffectType()) {
+            case HEAL_HP -> "Heals " + item.getEffectValue() + " HP";
+            case RESTORE_EP -> "Restores " + item.getEffectValue() + " EP";
+            case REVIVE -> "Revives with " + item.getEffectValue() + "% HP";
+            case GRANT_IMMUNITY -> "Grants immunity for " + item.getEffectValue() + " turn(s)";
+        };
     }
 }

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -425,9 +425,9 @@ public void actionPerformed(ActionEvent e) {
             if (character.getBattlesWon() % Constants.WINS_PER_REWARD == 0) {
                 MagicItem reward = generateUniqueReward(character);
                 character.getInventory().addItem(reward);
-                javax.swing.JOptionPane.showMessageDialog(null,
-                        "New Magic Item awarded: " + reward.getName() +
-                        "\n" + reward.getDescription(),
+                javax.swing.JOptionPane.showMessageDialog(
+                        null,
+                        formatAwardMessage(reward),
                         "Item Awarded",
                         javax.swing.JOptionPane.INFORMATION_MESSAGE);
             }
@@ -454,5 +454,30 @@ public void actionPerformed(ActionEvent e) {
             attempts++;
         }
         return reward;
+    }
+
+    /** Formats a popup message describing the awarded item. */
+    private String formatAwardMessage(MagicItem item) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Congratulations! You received a ")
+          .append(item.getRarityType()).append(' ')
+          .append(item.getItemType()).append(" Item: ")
+          .append(item.getName()).append('!');
+        if (item instanceof model.item.SingleUseItem su) {
+            sb.append("\nEffect: ").append(describeEffect(su));
+        } else {
+            sb.append("\nEffect: ").append(item.getDescription());
+        }
+        return sb.toString();
+    }
+
+    private String describeEffect(model.item.SingleUseItem item) {
+        return switch (item.getEffectType()) {
+            case HEAL_HP -> "Heals " + item.getEffectValue() + " HP";
+            case RESTORE_EP -> "Restores " + item.getEffectValue() + " EP";
+            case REVIVE -> "Revives with " + item.getEffectValue() + "% HP";
+            case GRANT_IMMUNITY ->
+                    "Grants immunity for " + item.getEffectValue() + " turn(s)";
+        };
     }
 }

--- a/model/item/MagicItem.java
+++ b/model/item/MagicItem.java
@@ -40,8 +40,11 @@ public abstract class MagicItem implements Serializable {
     /** PASSIVE or SINGLE_USE, never {@code null}. */
     private final ItemType itemType;
 
-    /** Rarity tag (“COMMON”, “RARE”, etc.), cannot be blank. */
-    private final String rarity;
+    /** Rarity tier of this item. */
+    private final RarityType rarityType;
+
+    /** Cached drop chance percentage from {@link #rarityType}. */
+    private final int dropChance;
 
     /**
      * Constructs an immutable magic item.
@@ -49,23 +52,24 @@ public abstract class MagicItem implements Serializable {
      * @param name        non-blank display name
      * @param description non-blank description
      * @param type        non-null {@link ItemType}
-     * @param rarity      non-blank rarity label
+     * @param rarity      rarity tier of the item
      * @throws GameException if any argument violates a pre-condition
      */
     protected MagicItem(String name,
                         String description,
                         ItemType type,
-                        String rarity) throws GameException {
+                        RarityType rarity) throws GameException {
 
         InputValidator.requireNonBlank(name, "item name");
         InputValidator.requireNonBlank(description, "item description");
         InputValidator.requireNonNull(type, "item type");
-        InputValidator.requireNonBlank(rarity, "item rarity");
+        InputValidator.requireNonNull(rarity, "item rarity");
 
         this.name = name;
         this.description = description;
         this.itemType = type;
-        this.rarity = rarity;
+        this.rarityType = rarity;
+        this.dropChance = rarity.getDropChance();
     }
 
     /** @return immutable item name */
@@ -99,7 +103,7 @@ public abstract class MagicItem implements Serializable {
         return name.equals(that.name)
                 && description.equals(that.description)
                 && itemType == that.itemType
-                && rarity.equals(that.rarity);
+                && rarityType == that.rarityType;
     }
 
     /**
@@ -109,7 +113,7 @@ public abstract class MagicItem implements Serializable {
      */
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name, description, itemType, rarity);
+        return java.util.Objects.hash(name, description, itemType, rarityType);
     }
 
     /**
@@ -120,9 +124,19 @@ public abstract class MagicItem implements Serializable {
         return getName() + " (" + itemType + ")";
     }
 
-    /** @return rarity string (“COMMON”, “RARE”, etc.) */
+    /** @return rarity string (“Common”, “Rare”, etc.) */
     public String getRarity() {
-        return rarity;
+        return rarityType.toString();
+    }
+
+    /** @return rarity enumeration value */
+    public RarityType getRarityType() {
+        return rarityType;
+    }
+
+    /** @return percentage chance this item’s rarity drops */
+    public int getDropChance() {
+        return dropChance;
     }
 
     /**

--- a/model/item/PassiveItem.java
+++ b/model/item/PassiveItem.java
@@ -27,10 +27,10 @@ public final class PassiveItem extends MagicItem {
      *
      * @param name        the item's display name (non-blank)
      * @param description tooltip text / effect blurb (non-blank)
-     * @param rarity      rarity label (e.g., "Common", "Legendary")
+     * @param rarity      item rarity tier
      * @throws GameException if any parameter fails validation
      */
-    public PassiveItem(String name, String description, String rarity) throws GameException {
+    public PassiveItem(String name, String description, RarityType rarity) throws GameException {
         super(name, description, ItemType.PASSIVE, rarity);
     }
 
@@ -41,6 +41,6 @@ public final class PassiveItem extends MagicItem {
      */
     @Override
     public MagicItem copy() {
-        return new PassiveItem(getName(), getDescription(), getRarity());
+        return new PassiveItem(getName(), getDescription(), getRarityType());
     }
 }

--- a/model/item/RarityType.java
+++ b/model/item/RarityType.java
@@ -1,0 +1,30 @@
+package model.item;
+
+/**
+ * Enumerates item rarity tiers and their drop chances.
+ */
+public enum RarityType {
+    /** Common items drop 60% of the time. */
+    COMMON(60),
+    /** Uncommon items drop 35% of the time. */
+    UNCOMMON(35),
+    /** Rare items drop 5% of the time. */
+    RARE(5);
+
+    private final int dropChance;
+
+    RarityType(int chance) {
+        this.dropChance = chance;
+    }
+
+    /** @return the percentage drop chance for this rarity */
+    public int getDropChance() {
+        return dropChance;
+    }
+
+    @Override
+    public String toString() {
+        String n = name().toLowerCase();
+        return Character.toUpperCase(n.charAt(0)) + n.substring(1);
+    }
+}

--- a/model/item/SingleUseItem.java
+++ b/model/item/SingleUseItem.java
@@ -40,12 +40,12 @@ public final class SingleUseItem extends MagicItem {
      *
      * @param name        display name (non-blank)
      * @param description tooltip or flavour text (non-blank)
-     * @param rarity      rarity label (non-blank)
+     * @param rarity      rarity tier (non-null)
      * @param effectType  type of effect when used (non-null)
      * @param effectValue numeric value of the effect (1..MAX_EFFECT_VALUE)
      * @throws GameException if any argument fails validation
      */
-    public SingleUseItem(String name, String description, String rarity,
+    public SingleUseItem(String name, String description, RarityType rarity,
                          SingleUseEffectType effectType, int effectValue)
             throws GameException {
         super(name, description, ItemType.SINGLE_USE, rarity);
@@ -102,7 +102,7 @@ public final class SingleUseItem extends MagicItem {
      */
     @Override
     public MagicItem copy() {
-        return new SingleUseItem(getName(), getDescription(), getRarity(),
+        return new SingleUseItem(getName(), getDescription(), getRarityType(),
                 effectType, effectValue);
     }
 

--- a/src/test/java/controller/InventoryControllerTest.java
+++ b/src/test/java/controller/InventoryControllerTest.java
@@ -4,6 +4,7 @@ import model.core.ClassType;
 import model.core.Character;
 import model.core.RaceType;
 import model.item.PassiveItem;
+import model.item.RarityType;
 import model.item.SingleUseEffectType;
 import model.item.SingleUseItem;
 import model.util.GameException;
@@ -28,7 +29,7 @@ public class InventoryControllerTest {
 
     @Test
     public void testEquipAndUnequip() throws GameException {
-        PassiveItem item = new PassiveItem("Ring", "Nice ring", "Common");
+        PassiveItem item = new PassiveItem("Ring", "Nice ring", RarityType.COMMON);
         character.getInventory().addItem(item);
         controller.handleEquipItemRequest(item);
         assertEquals(item, character.getInventory().getEquippedItem());
@@ -39,7 +40,7 @@ public class InventoryControllerTest {
 
     @Test
     public void testUseSingleUseItem() throws GameException {
-        SingleUseItem potion = new SingleUseItem("Potion", "Heal", "Common", SingleUseEffectType.HEAL_HP, 10);
+        SingleUseItem potion = new SingleUseItem("Potion", "Heal", RarityType.COMMON, SingleUseEffectType.HEAL_HP, 10);
         character.getInventory().addItem(potion);
         controller.handleUseItemRequest(potion);
         assertFalse(character.getInventory().getAllItems().contains(potion));

--- a/src/test/java/controller/TradeControllerTest.java
+++ b/src/test/java/controller/TradeControllerTest.java
@@ -6,6 +6,7 @@ import model.core.Player;
 import model.core.RaceType;
 import model.item.PassiveItem;
 import model.item.MagicItem;
+import model.item.RarityType;
 import model.util.GameException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,8 @@ public class TradeControllerTest {
         p2 = new Player("Bob");
         c1 = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
         c2 = new Character("B", RaceType.ELF, ClassType.MAGE, List.of());
-        item1 = new PassiveItem("Ring", "", "Common");
-        item2 = new PassiveItem("Amulet", "", "Common");
+        item1 = new PassiveItem("Ring", "", RarityType.COMMON);
+        item2 = new PassiveItem("Amulet", "", RarityType.COMMON);
         c1.getInventory().addItem(item1);
         c2.getInventory().addItem(item2);
         p1.addCharacter(c1);
@@ -55,7 +56,7 @@ public class TradeControllerTest {
 
     @Test
     public void testTradeNonOwnedItemFails() {
-        PassiveItem other = new PassiveItem("Other", "", "Common");
+        PassiveItem other = new PassiveItem("Other", "", RarityType.COMMON);
         assertThrows(GameException.class, () ->
                 controller.executeTrade(c1, List.of(other), c2, List.of(item2)));
 

--- a/src/test/java/model/core/CharacterInventoryTest.java
+++ b/src/test/java/model/core/CharacterInventoryTest.java
@@ -1,6 +1,7 @@
 package model.core;
 
 import model.item.PassiveItem;
+import model.item.RarityType;
 import model.item.SingleUseEffectType;
 import model.item.SingleUseItem;
 import model.util.GameException;
@@ -18,7 +19,7 @@ public class CharacterInventoryTest {
     @Test
     public void testEquipAndUnequipDelegation() throws GameException {
         Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR, List.of());
-        PassiveItem ring = new PassiveItem("Ring", "", "Common");
+        PassiveItem ring = new PassiveItem("Ring", "", RarityType.COMMON);
         c.getInventory().addItem(ring);
 
         c.equipItem(ring);
@@ -31,7 +32,7 @@ public class CharacterInventoryTest {
     @Test
     public void testHasItemAndUseSingleUseItem() throws GameException {
         Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR, List.of());
-        SingleUseItem potion = new SingleUseItem("Potion", "", "Common", SingleUseEffectType.HEAL_HP, 10);
+        SingleUseItem potion = new SingleUseItem("Potion", "", RarityType.COMMON, SingleUseEffectType.HEAL_HP, 10);
         c.getInventory().addItem(potion);
 
         assertTrue(c.hasItem(potion));

--- a/src/test/java/model/item/MagicItemEffectTest.java
+++ b/src/test/java/model/item/MagicItemEffectTest.java
@@ -6,6 +6,7 @@ import model.core.Character;
 import model.core.RaceType;
 import model.util.GameException;
 import model.util.StatusEffectType;
+import model.item.RarityType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public class MagicItemEffectTest {
     public void testPotionOfMinorHealing() throws GameException {
         Character c = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
         c.takeDamage(30);
-        SingleUseItem item = new SingleUseItem("Potion of Minor Healing", "Heals", "Common",
+        SingleUseItem item = new SingleUseItem("Potion of Minor Healing", "Heals", RarityType.COMMON,
                 SingleUseEffectType.HEAL_HP, 40);
         item.applyEffect(c, new CombatLog());
         assertEquals(c.getMaxHp(), c.getCurrentHp());
@@ -28,7 +29,7 @@ public class MagicItemEffectTest {
     public void testScrollOfMinorEnergy() throws GameException {
         Character c = new Character("B", RaceType.HUMAN, ClassType.WARRIOR, List.of());
         c.spendEp(c.getCurrentEp());
-        SingleUseItem item = new SingleUseItem("Scroll of Minor Energy", "EP", "Common",
+        SingleUseItem item = new SingleUseItem("Scroll of Minor Energy", "EP", RarityType.COMMON,
                 SingleUseEffectType.RESTORE_EP, 20);
         item.applyEffect(c, new CombatLog());
         assertEquals(20, c.getCurrentEp());
@@ -37,7 +38,7 @@ public class MagicItemEffectTest {
     @Test
     public void testDefendersAegisAppliesImmunity() throws GameException {
         Character c = new Character("C", RaceType.HUMAN, ClassType.WARRIOR, List.of());
-        SingleUseItem item = new SingleUseItem("Defender's Aegis", "Immune", "Common",
+        SingleUseItem item = new SingleUseItem("Defender's Aegis", "Immune", RarityType.COMMON,
                 SingleUseEffectType.GRANT_IMMUNITY, 1);
         item.applyEffect(c, new CombatLog());
         assertTrue(c.hasStatusEffect(StatusEffectType.IMMUNITY));

--- a/src/test/java/model/item/MagicItemFactoryTest.java
+++ b/src/test/java/model/item/MagicItemFactoryTest.java
@@ -2,6 +2,7 @@ package model.item;
 
 import model.service.MagicItemFactory;
 import org.junit.jupiter.api.Test;
+import model.item.RarityType;
 
 import java.util.Random;
 
@@ -22,10 +23,10 @@ public class MagicItemFactoryTest {
     @Test
     public void testRarityBoundaries() {
         MagicItem common = MagicItemFactory.createRandomReward(new FixedRandom(10,0));
-        assertEquals("Common", common.getRarity());
+        assertEquals(RarityType.COMMON, common.getRarityType());
         MagicItem uncommon = MagicItemFactory.createRandomReward(new FixedRandom(60,0));
-        assertEquals("Uncommon", uncommon.getRarity());
+        assertEquals(RarityType.UNCOMMON, uncommon.getRarityType());
         MagicItem rare = MagicItemFactory.createRandomReward(new FixedRandom(98,0));
-        assertEquals("Rare", rare.getRarity());
+        assertEquals(RarityType.RARE, rare.getRarityType());
     }
 }


### PR DESCRIPTION
## Summary
- add `RarityType` enum with associated drop chances
- update `MagicItem` and subclasses to store rarity and drop chance
- refactor `MagicItemFactory` to use the new rarity model
- display detailed award popups in `GameManagerController` and `BattleController`
- update tests and item constructors for the new API

## Testing
- `javac @sources_list.txt`

------
https://chatgpt.com/codex/tasks/task_e_688736b3d4b883288195cb5ee31e8743