### PR TITLE
Fix status duplication and reward frequency

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -607,7 +607,8 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
         if (!c.getActiveStatusEffects().isEmpty()) {
             String statuses = c.getActiveStatusEffects().stream()
                     .map(se -> se.getType().name())
-                    .collect(Collectors.joining(","));
+                    .distinct()
+                    .collect(Collectors.joining(", "));
             return base + " | " + statuses;
         }
         return base;

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -422,7 +422,7 @@ public void actionPerformed(ActionEvent e) {
             hallOfFameController.addWinForPlayer(winner);
             hallOfFameController.addWinForCharacter(character);
 
-            if (character.getBattlesWon() % Constants.WINS_PER_REWARD == 0) {
+            if (winner.getCumulativeWins() % Constants.WINS_PER_REWARD == 0) {
                 MagicItem reward = generateUniqueReward(character);
                 character.getInventory().addItem(reward);
                 javax.swing.JOptionPane.showMessageDialog(

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -427,6 +427,8 @@ public class Character implements Serializable {
         if (activeStatusEffects.size() >= Constants.MAX_STATUS_EFFECTS) {
             return; // Or throw exception
         }
+        // Avoid stacking duplicate status types; refresh the effect instead
+        activeStatusEffects.removeIf(se -> se.getType() == effect.getType());
         activeStatusEffects.add(effect);
         effect.applyEffect(this);
     }

--- a/src/test/java/controller/BattleStatusFormatTest.java
+++ b/src/test/java/controller/BattleStatusFormatTest.java
@@ -1,0 +1,40 @@
+package controller;
+
+import model.core.Character;
+import model.core.ClassType;
+import model.core.RaceType;
+import model.util.StatusEffectFactory;
+import model.util.StatusEffectType;
+import model.util.GameException;
+import org.junit.jupiter.api.Test;
+import view.BattleView;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BattleStatusFormatTest {
+    private static class DummyView extends BattleView {
+        DummyView() {
+            super(1);
+        }
+        @Override public void displayBattleStart(Character c1, Character c2) {}
+        @Override public void displayTurnResults(model.battle.CombatLog log) {}
+        @Override public void displayBattleEnd(Character winner) {}
+    }
+
+    @Test
+    public void testFormatStatusDeduplicates() throws Exception {
+        Character c = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        c.addStatusEffect(StatusEffectFactory.create(StatusEffectType.POISONED));
+        c.addStatusEffect(StatusEffectFactory.create(StatusEffectType.POISONED));
+
+        BattleController bc = new BattleController(new DummyView());
+        Method m = BattleController.class.getDeclaredMethod("formatStatus", Character.class);
+        m.setAccessible(true);
+        String result = (String) m.invoke(bc, c);
+        assertTrue(result.contains("POISONED"));
+        assertFalse(result.contains("POISONED, POISONED"));
+    }
+}

--- a/src/test/java/controller/CumulativeWinRewardTest.java
+++ b/src/test/java/controller/CumulativeWinRewardTest.java
@@ -1,0 +1,63 @@
+package controller;
+
+import model.core.ClassType;
+import model.core.Character;
+import model.core.Player;
+import model.core.RaceType;
+import model.util.Constants;
+import model.util.GameException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import persistence.GameData;
+import persistence.SaveLoadService;
+
+import javax.swing.JFrame;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CumulativeWinRewardTest {
+    @BeforeEach
+    @AfterEach
+    public void clean() {
+        new File(Constants.SAVE_FILE_PATH).delete();
+    }
+
+    private GameManagerController buildController() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        SceneManager sm = new SceneManager();
+        Field f = SceneManager.class.getDeclaredField("gameManagerController");
+        f.setAccessible(true);
+        GameManagerController controller = (GameManagerController) f.get(sm);
+        Field stageField = SceneManager.class.getDeclaredField("stage");
+        stageField.setAccessible(true);
+        JFrame stage = (JFrame) stageField.get(sm);
+        stage.dispose();
+        return controller;
+    }
+
+    @Test
+    public void testRewardAfterThreeCumulativeWins() throws Exception {
+        Player p = new Player("P");
+        Character c1 = new Character("C1", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        Character c2 = new Character("C2", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        p.addCharacter(c1);
+        p.addCharacter(c2);
+        SaveLoadService.saveGame(new GameData(List.of(p), List.of()));
+
+        GameManagerController controller = buildController();
+        Player loaded = controller.getPlayers().get(0);
+        Character lc1 = loaded.getCharacters().get(0);
+        Character lc2 = loaded.getCharacters().get(1);
+
+        controller.handlePlayerWin(loaded, lc1); // win 1
+        controller.handlePlayerWin(loaded, lc2); // win 2
+        assertEquals(0, lc1.getInventory().getAllItems().size());
+        assertEquals(0, lc2.getInventory().getAllItems().size());
+        controller.handlePlayerWin(loaded, lc1); // win 3 triggers reward
+        assertEquals(1, lc1.getInventory().getAllItems().size());
+    }
+}


### PR DESCRIPTION
## Summary
- prevent duplicate status effects on characters
- show unique status effects in `BattleController`
- reward magic items every three cumulative wins instead of per-character wins
- add tests for status formatting and cumulative win rewards

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6887566591348328ba78a76fc58f53f7