### PR TITLE
Show XP and level in battle status

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -602,8 +602,11 @@ Optional<Ability> abilityOpt = user.getAbilities().stream()
     }
 
     private String formatStatus(Character c) {
-        String base = String.format("HP %d/%d | EP %d/%d", c.getCurrentHp(), c.getMaxHp(),
-                c.getCurrentEp(), c.getMaxEp());
+        String base = String.format(
+                "HP %d/%d | EP %d/%d | XP %d | Level %d",
+                c.getCurrentHp(), c.getMaxHp(),
+                c.getCurrentEp(), c.getMaxEp(),
+                c.getXp(), c.getLevel());
         if (!c.getActiveStatusEffects().isEmpty()) {
             String statuses = c.getActiveStatusEffects().stream()
                     .map(se -> se.getType().name())

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -301,9 +301,9 @@ public class BattleView extends JFrame {
 
         // Status Area
         RoundedDisplayBox statusPanel = new RoundedDisplayBox();
-        statusPanel.setPreferredSize(new Dimension(280, 40));
-        statusPanel.setMaximumSize(new Dimension(280, 40));
-        statusPanel.setMinimumSize(new Dimension(280, 40));
+        statusPanel.setPreferredSize(new Dimension(280, 60));
+        statusPanel.setMaximumSize(new Dimension(280, 60));
+        statusPanel.setMinimumSize(new Dimension(280, 60));
         statusPanel.setLayout(new BorderLayout());
         statusPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 


### PR DESCRIPTION
## Summary
- extend `formatStatus` to display XP and Level in battle UI
- enlarge status panel in `BattleView` so the new text fits

## Testing
- `mvn test` *(fails: Could not resolve maven-resources-plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68877317c6c48328bbc0d73fd89f53b3