### PR TITLE
Fix passive item effect & clean battle dropdowns

### DIFF
--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -63,6 +63,7 @@ public class Character implements Serializable {
     private boolean isStunned;
     private boolean statusEffectImmunityUsed;
     private boolean phoenixReviveUsed;
+    private boolean vitalityBonusApplied;
 
     // --- Copy constructor for deep copy ---
     public Character(Character other) throws GameException {
@@ -95,6 +96,7 @@ public class Character implements Serializable {
         this.isStunned = false;
         this.statusEffectImmunityUsed = false;
         this.phoenixReviveUsed = false;
+        this.vitalityBonusApplied = false;
     }
 
     // --- Method to create a copy for battle ---
@@ -135,6 +137,7 @@ public class Character implements Serializable {
 
         this.activeStatusEffects.clear();
         this.isStunned = false;
+        this.vitalityBonusApplied = false;
 
         initializeStats();
         if (!this.abilities.isEmpty()) {
@@ -442,6 +445,9 @@ public class Character implements Serializable {
     public boolean isStunned() { return this.isStunned; }
     public void setStunned(boolean stunned) { this.isStunned = stunned; }
 
+    public boolean isVitalityBonusApplied() { return vitalityBonusApplied; }
+    public void setVitalityBonusApplied(boolean applied) { this.vitalityBonusApplied = applied; }
+
     /**
      * Processes all active status effects at the start of this character's turn.
      * Effects are updated and removed when their duration expires.
@@ -534,5 +540,6 @@ public class Character implements Serializable {
         // ensure booleans are initialised
         statusEffectImmunityUsed = false;
         phoenixReviveUsed = false;
+        vitalityBonusApplied = false;
     }
 }

--- a/src/test/java/controller/PassiveItemEffectTest.java
+++ b/src/test/java/controller/PassiveItemEffectTest.java
@@ -1,0 +1,46 @@
+package controller;
+
+import model.core.ClassType;
+import model.core.Character;
+import model.core.RaceType;
+import model.item.PassiveItem;
+import model.item.RarityType;
+import model.util.GameException;
+import model.battle.CombatLog;
+import view.BattleView;
+import org.junit.jupiter.api.Test;
+import javax.swing.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PassiveItemEffectTest {
+
+    private static class CaptureView extends BattleView {
+        List<String> logEntries;
+        CaptureView() { super(1); }
+        @Override public void displayBattleStart(Character c1, Character c2) {}
+        @Override public void displayTurnResults(CombatLog log) { logEntries = log.getLogEntries(); }
+        @Override public void displayBattleEnd(Character winner) {}
+    }
+
+    @Test
+    public void testAmuletOfVitalityIncreasesMaxHp() throws GameException {
+        System.setProperty("java.awt.headless", "true");
+        Character c1 = new Character("A", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        Character c2 = new Character("B", RaceType.HUMAN, ClassType.WARRIOR, List.of());
+        PassiveItem amulet = new PassiveItem("Amulet of Vitality", "", RarityType.UNCOMMON);
+        c1.getInventory().addItem(amulet);
+        c1.getInventory().equipItem(amulet);
+        int baseHp = c1.getMaxHp();
+
+        CaptureView view = new CaptureView();
+        BattleController bc = new BattleController(view);
+        bc.startBattle(c1, c2);
+        Character battleCopy = bc.getBattleCopy(c1);
+        assertEquals(baseHp + 20, battleCopy.getMaxHp());
+        assertNotNull(view.logEntries);
+        boolean logged = view.logEntries.stream().anyMatch(e -> e.contains("Amulet of Vitality"));
+        assertTrue(logged);
+    }
+}


### PR DESCRIPTION
## Summary
- simplify text shown in battle dropdowns
- implement Amulet of Vitality passive effect and log message
- track vitality bonus in Character
- add unit test for Amulet of Vitality

## Testing
- `mvn test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6887a4a505808328823826f209bd54d9