### PR TITLE
Refactor BattleView layout

### DIFF
--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -24,12 +24,14 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.JTextPane;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
 
 import model.battle.CombatLog;
 import model.core.Character;
 import view.OutlinedLabel;
-
-// import controller._;
 
 /**
  * The battle view for Fatal Fantasy: Tactics Game.
@@ -56,7 +58,8 @@ public class BattleView extends JFrame {
     private JComboBox<String> cmbP1Abilities = new JComboBox<>();
     private JComboBox<String> cmbP2Abilities = new JComboBox<>();
     private JTextArea p1NameCharNameArea, p2NameCharNameArea, p1StatusArea, p2StatusArea;
-    private JTextArea p1AbilitiesItemsArea, p2AbilitiesItemsArea, battleLogArea, battleOutcomeArea;
+    private JTextArea p1AbilitiesItemsArea, p2AbilitiesItemsArea, battleLogArea;
+    private JTextPane battleOutcomeArea;
     private OutlinedLabel roundLabel;
     private int lastLogIndex = 0;
     
@@ -201,13 +204,18 @@ public class BattleView extends JFrame {
         battleOutcomePanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         // Text area for battle outcome
-        battleOutcomeArea = new JTextArea();
+        battleOutcomeArea = new JTextPane();
         battleOutcomeArea.setFont(new Font("Serif", Font.PLAIN, 18));
         battleOutcomeArea.setForeground(Color.WHITE);
         battleOutcomeArea.setOpaque(false);
         battleOutcomeArea.setEditable(false);
-        battleOutcomeArea.setLineWrap(true);
-        battleOutcomeArea.setWrapStyleWord(true);
+
+        // Center align text
+        StyledDocument doc = battleOutcomeArea.getStyledDocument();
+        SimpleAttributeSet center = new SimpleAttributeSet();
+        StyleConstants.setAlignment(center, StyleConstants.ALIGN_CENTER);
+        doc.setParagraphAttributes(0, doc.getLength(), center, false);
+
         battleOutcomePanel.add(battleOutcomeArea, BorderLayout.CENTER);
 
         centerPanel.add(battleLogPanel);
@@ -273,9 +281,9 @@ public class BattleView extends JFrame {
 
         // Name/CharName Area
         RoundedDisplayBox nameCharNamePanel = new RoundedDisplayBox();
-        nameCharNamePanel.setPreferredSize(new Dimension(280, 40));
-        nameCharNamePanel.setMaximumSize(new Dimension(280, 40));
-        nameCharNamePanel.setMinimumSize(new Dimension(280, 40));
+        nameCharNamePanel.setPreferredSize(new Dimension(280, 60));
+        nameCharNamePanel.setMaximumSize(new Dimension(280, 60));
+        nameCharNamePanel.setMinimumSize(new Dimension(280, 60));
         nameCharNamePanel.setLayout(new BorderLayout());
         nameCharNamePanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
@@ -297,13 +305,14 @@ public class BattleView extends JFrame {
         nameCharNameArea.setEditable(false);
         nameCharNameArea.setLineWrap(true);
         nameCharNameArea.setWrapStyleWord(true);
+        nameCharNameArea.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         nameCharNamePanel.add(nameCharNameArea, BorderLayout.CENTER);
 
         // Status Area
         RoundedDisplayBox statusPanel = new RoundedDisplayBox();
-        statusPanel.setPreferredSize(new Dimension(280, 40));
-        statusPanel.setMaximumSize(new Dimension(280, 40));
-        statusPanel.setMinimumSize(new Dimension(280, 40));
+        statusPanel.setPreferredSize(new Dimension(280, 60));
+        statusPanel.setMaximumSize(new Dimension(280, 60));
+        statusPanel.setMinimumSize(new Dimension(280, 60));
         statusPanel.setLayout(new BorderLayout());
         statusPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
@@ -325,6 +334,7 @@ public class BattleView extends JFrame {
         statusArea.setEditable(false);
         statusArea.setLineWrap(true);
         statusArea.setWrapStyleWord(true);
+        statusArea.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
         statusPanel.add(statusArea, BorderLayout.CENTER);
 
         panel.add(nameCharNamePanel);
@@ -333,9 +343,9 @@ public class BattleView extends JFrame {
 
         // Abilities/Items Area
         RoundedDisplayBox abilitiesItemsPanel = new RoundedDisplayBox();
-        abilitiesItemsPanel.setPreferredSize(new Dimension(280, 200));
-        abilitiesItemsPanel.setMaximumSize(new Dimension(280, 200));
-        abilitiesItemsPanel.setMinimumSize(new Dimension(280, 200));
+        abilitiesItemsPanel.setPreferredSize(new Dimension(280, 160));
+        abilitiesItemsPanel.setMaximumSize(new Dimension(280, 160));
+        abilitiesItemsPanel.setMinimumSize(new Dimension(280, 160));
         abilitiesItemsPanel.setLayout(new BorderLayout());
         abilitiesItemsPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
@@ -533,6 +543,12 @@ public class BattleView extends JFrame {
      */
     public void setBattleOutcome(String text) {
         battleOutcomeArea.setText(text);
+
+        // Reapply center alignment after setting text
+        StyledDocument doc = battleOutcomeArea.getStyledDocument();
+        SimpleAttributeSet center = new SimpleAttributeSet();
+        StyleConstants.setAlignment(center, StyleConstants.ALIGN_CENTER);
+        doc.setParagraphAttributes(0, doc.getLength(), center, false);
     }
 
     /** Clears any text from the battle outcome area. */


### PR DESCRIPTION
## Summary
- switch BattleView outcome panel to `JTextPane` for center aligned text
- update imports and modify `setBattleOutcome` to maintain alignment
- tweak player info panel dimensions and add padding borders
- reduce ability/items panel size

## Testing
- `mvn -q test` *(fails: maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68883fa2f3348328af92ea19626b316d