### PR TITLE
Refactor to remove early returns

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -459,11 +459,11 @@ public final class BattleController {
      * persistent character instance.
      */
     private void syncInventory(Character persistent, Character battleCopy) {
-        if (persistent == null || battleCopy == null) return;
+        if (persistent != null && battleCopy != null) {
 
-        Map<String, Long> remaining = battleCopy.getInventory().getAllItems().stream()
-                .filter(i -> i instanceof SingleUseItem)
-                .collect(Collectors.groupingBy(MagicItem::getName, Collectors.counting()));
+            Map<String, Long> remaining = battleCopy.getInventory().getAllItems().stream()
+                    .filter(i -> i instanceof SingleUseItem)
+                    .collect(Collectors.groupingBy(MagicItem::getName, Collectors.counting()));
 
         List<MagicItem> originalItems = new ArrayList<>(persistent.getInventory().getAllItems());
         Map<String, Long> counts = new HashMap<>();
@@ -473,13 +473,14 @@ public final class BattleController {
             }
         }
 
-        for (MagicItem item : originalItems) {
-            if (item instanceof SingleUseItem) {
-                long have = counts.getOrDefault(item.getName(), 0L);
-                long keep = remaining.getOrDefault(item.getName(), 0L);
-                if (have > keep) {
-                    persistent.getInventory().removeItem(item);
-                    counts.put(item.getName(), have - 1);
+            for (MagicItem item : originalItems) {
+                if (item instanceof SingleUseItem) {
+                    long have = counts.getOrDefault(item.getName(), 0L);
+                    long keep = remaining.getOrDefault(item.getName(), 0L);
+                    if (have > keep) {
+                        persistent.getInventory().removeItem(item);
+                        counts.put(item.getName(), have - 1);
+                    }
                 }
             }
         }

--- a/controller/BattleModesController.java
+++ b/controller/BattleModesController.java
@@ -44,21 +44,21 @@ public class BattleModesController implements ActionListener {
         if (players.size() < 2) {
             JOptionPane.showMessageDialog(view, "Two players required for PvP.",
                     "Error", JOptionPane.ERROR_MESSAGE);
-            return;
+        } else {
+            view.dispose();
+            new BattleSetupController(sceneManager, players)
+                    .startPvP();
         }
-        view.dispose();
-        new BattleSetupController(sceneManager, players)
-                .startPvP();
     }
 
     private void handlePvB() {
         if (players.isEmpty()) {
             JOptionPane.showMessageDialog(view, "No players registered.",
                     "Error", JOptionPane.ERROR_MESSAGE);
-            return;
+        } else {
+            view.dispose();
+            new BattleSetupController(sceneManager, players)
+                    .startPvB();
         }
-        view.dispose();
-        new BattleSetupController(sceneManager, players)
-                .startPvB();
     }
 }

--- a/controller/CharacterGeneratorController.java
+++ b/controller/CharacterGeneratorController.java
@@ -108,14 +108,14 @@ public final class CharacterGeneratorController {
             String chosenName = view.getCharacterName().trim();
             if (chosenName.isEmpty()) {
                 view.showErrorMessage("Please enter a character name first.");
-                return;
-            }
-            boolean confirmed = view.confirmCharacterCreation(chosenName);
-            if (confirmed) {
-                Character finalChar = generateRandomCharacterWithName(chosenName);
-                saveCallback.accept(finalChar);
-                view.showInfoMessage("Character \"" + chosenName + "\" created!");
-                view.resetFields();
+            } else {
+                boolean confirmed = view.confirmCharacterCreation(chosenName);
+                if (confirmed) {
+                    Character finalChar = generateRandomCharacterWithName(chosenName);
+                    saveCallback.accept(finalChar);
+                    view.showInfoMessage("Character \"" + chosenName + "\" created!");
+                    view.resetFields();
+                }
             }
         } catch (GameException ge) {
             view.showErrorMessage("Creation failed: " + ge.getMessage());

--- a/controller/CharacterManagementMenuController.java
+++ b/controller/CharacterManagementMenuController.java
@@ -54,15 +54,15 @@ public class CharacterManagementMenuController {
                     "Info", JOptionPane.INFORMATION_MESSAGE);
             view.setPlayer1Name(null);
             view.setPlayer2Name(null);
-            return;
-        }
-        if (players.size() > 0) {
-            view.setPlayer1Name(players.get(0).getName());
-        }
-        if (players.size() > 1) {
-            view.setPlayer2Name(players.get(1).getName());
         } else {
-            view.setPlayer2Name(null);
+            if (players.size() > 0) {
+                view.setPlayer1Name(players.get(0).getName());
+            }
+            if (players.size() > 1) {
+                view.setPlayer2Name(players.get(1).getName());
+            } else {
+                view.setPlayer2Name(null);
+            }
         }
     }
 }

--- a/controller/CharacterManualCreationController.java
+++ b/controller/CharacterManualCreationController.java
@@ -183,23 +183,23 @@ public final class CharacterManualCreationController {
         String classStr = view.getSelectedClass();
         if (classStr == null || classStr.isBlank()) {
             clearAbilityOptions();
-            return;
-        }
-        try {
-            ClassType classType = ClassType.valueOf(classStr);
-            List<String> abilityNames = classService.getAvailableAbilities(classType)
-                    .stream().map(Ability::getName).collect(Collectors.toList());
-            String[] options = abilityNames.toArray(new String[0]);
-            view.setAbilityOptions(1, options);
+        } else {
+            try {
+                ClassType classType = ClassType.valueOf(classStr);
+                List<String> abilityNames = classService.getAvailableAbilities(classType)
+                        .stream().map(Ability::getName).collect(Collectors.toList());
+                String[] options = abilityNames.toArray(new String[0]);
+                view.setAbilityOptions(1, options);
             view.setAbilityOptions(2, options);
             view.setAbilityOptions(3, options);
 
             String raceStr = view.getSelectedRace();
-            if (raceStr != null && !raceStr.isBlank() && RaceType.valueOf(raceStr) == RaceType.GNOME) {
-                view.setAbilityOptions(4, options);
+                if (raceStr != null && !raceStr.isBlank() && RaceType.valueOf(raceStr) == RaceType.GNOME) {
+                    view.setAbilityOptions(4, options);
+                }
+            } catch (Exception e) {
+                clearAbilityOptions();
             }
-        } catch (Exception e) {
-            clearAbilityOptions();
         }
     }
 

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -425,25 +425,22 @@ public void actionPerformed(ActionEvent e) {
             InputValidator.requireNonNull(character, "character");
 
             // Skip Hall of Fame updates for AI-controlled bots
-            if ("Bot".equalsIgnoreCase(winner.getName())) {
-                return;
+            if (!"Bot".equalsIgnoreCase(winner.getName())) {
+                winner.incrementWins();
+                character.incrementBattlesWon();
+                hallOfFameController.addWinForPlayer(winner);
+                hallOfFameController.addWinForCharacter(character);
+
+                if (character.getBattlesWon() % Constants.WINS_PER_REWARD == 0) {
+                    MagicItem reward = generateUniqueReward(character);
+                    character.getInventory().addItem(reward);
+                    javax.swing.JOptionPane.showMessageDialog(
+                            null,
+                            formatAwardMessage(reward),
+                            "Item Awarded",
+                            javax.swing.JOptionPane.INFORMATION_MESSAGE);
+                }
             }
-
-            winner.incrementWins();
-            character.incrementBattlesWon();
-            hallOfFameController.addWinForPlayer(winner);
-            hallOfFameController.addWinForCharacter(character);
-
-            if (character.getBattlesWon() % Constants.WINS_PER_REWARD == 0) {
-                MagicItem reward = generateUniqueReward(character);
-                character.getInventory().addItem(reward);
-                javax.swing.JOptionPane.showMessageDialog(
-                        null,
-                        formatAwardMessage(reward),
-                        "Item Awarded",
-                        javax.swing.JOptionPane.INFORMATION_MESSAGE);
-            }
-
             SaveLoadService.saveGame(new GameData(players,
                                                  hallOfFameController.getHallOfFame()));
         } catch (GameException e) {

--- a/controller/TradeController.java
+++ b/controller/TradeController.java
@@ -217,20 +217,18 @@ public class TradeController implements ActionListener {
         List<MagicItem> cItems = view.getSelectedClientItems();
         if (merchant == null || client == null || merchant == client) {
             view.showError("Select two different characters.");
-            return;
-        }
-        if (mItems.isEmpty() && cItems.isEmpty()) {
+        } else if (mItems.isEmpty() && cItems.isEmpty()) {
             view.showError("Select at least one item to trade.");
-            return;
-        }
-        try {
-            executeTrade(merchant, mItems, client, cItems);
-            persist();
-            view.appendTradeLog(buildLogMessage(merchant, mItems, client, cItems));
-            view.showInfo("Trade completed successfully.");
-            view.refresh();
-        } catch (GameException ex) {
-            view.showError(ex.getMessage());
+        } else {
+            try {
+                executeTrade(merchant, mItems, client, cItems);
+                persist();
+                view.appendTradeLog(buildLogMessage(merchant, mItems, client, cItems));
+                view.showInfo("Trade completed successfully.");
+                view.refresh();
+            } catch (GameException ex) {
+                view.showError(ex.getMessage());
+            }
         }
     }
 

--- a/controller/TradingHallController.java
+++ b/controller/TradingHallController.java
@@ -71,20 +71,20 @@ public class TradingHallController implements ActionListener {
         if (mName == null || cName == null || mName.equals(cName)) {
             JOptionPane.showMessageDialog(view, "Select two different players.",
                     "Invalid Selection", JOptionPane.ERROR_MESSAGE);
-            return;
+        } else {
+            Player p1 = findPlayerByName(mName);
+            Player p2 = findPlayerByName(cName);
+            if (p1.getCharacters().isEmpty() || p2.getCharacters().isEmpty()) {
+                JOptionPane.showMessageDialog(view,
+                        "Both players must have at least one character to trade.",
+                        "Invalid Selection", JOptionPane.ERROR_MESSAGE);
+            } else {
+                System.out.println("TradingHallController starting trade between "
+                        + p1.getName() + " and " + p2.getName());
+                view.dispose();
+                sceneManager.showTradeView(p1, p2);
+            }
         }
-        Player p1 = findPlayerByName(mName);
-        Player p2 = findPlayerByName(cName);
-        if (p1.getCharacters().isEmpty() || p2.getCharacters().isEmpty()) {
-            JOptionPane.showMessageDialog(view,
-                    "Both players must have at least one character to trade.",
-                    "Invalid Selection", JOptionPane.ERROR_MESSAGE);
-            return;
-        }
-        System.out.println("TradingHallController starting trade between "
-                + p1.getName() + " and " + p2.getName());
-        view.dispose();
-        sceneManager.showTradeView(p1, p2);
     }
 
     private Player findPlayerByName(String name) {

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -219,9 +219,9 @@ public class Character implements Serializable {
      * @param damage The non-negative amount of damage to apply.
      */
     public void takeDamage(int damage) {
-        if (damage < 0) return;
+        if (damage >= 0) {
 
-        int finalDamage = damage;
+            int finalDamage = damage;
 
         if (hasStatusEffect(StatusEffectType.IMMUNITY)) {
             finalDamage = 0;
@@ -249,7 +249,8 @@ public class Character implements Serializable {
             finalDamage += 5;
         }
 
-        this.currentHp = Math.max(0, this.currentHp - finalDamage);
+            this.currentHp = Math.max(0, this.currentHp - finalDamage);
+        }
     }
 
     /**
@@ -280,8 +281,9 @@ public class Character implements Serializable {
      * @param healingAmount The non-negative amount of HP to restore.
      */
     public void heal(int healingAmount) {
-        if (healingAmount < 0) return;
-        this.currentHp = Math.min(this.maxHp, this.currentHp + healingAmount);
+        if (healingAmount >= 0) {
+            this.currentHp = Math.min(this.maxHp, this.currentHp + healingAmount);
+        }
     }
 
     /**
@@ -289,9 +291,10 @@ public class Character implements Serializable {
      * Current HP is boosted by the same value.
      */
     public void increaseMaxHp(int amount) {
-        if (amount <= 0) return;
-        this.maxHp += amount;
-        this.currentHp += amount;
+        if (amount > 0) {
+            this.maxHp += amount;
+            this.currentHp += amount;
+        }
     }
 
     /**
@@ -312,8 +315,9 @@ public class Character implements Serializable {
      * @param amount The non-negative amount of EP to restore.
      */
     public void gainEp(int amount) {
-        if (amount < 0) return;
-        this.currentEp = Math.min(this.maxEp, this.currentEp + amount);
+        if (amount >= 0) {
+            this.currentEp = Math.min(this.maxEp, this.currentEp + amount);
+        }
     }
 
     // --- Progression Management ---
@@ -324,8 +328,9 @@ public class Character implements Serializable {
      * @param amount The non-negative amount of XP to add.
      */
     public void addExperience(int amount) {
-        if (amount < 0) return;
-        this.experience += amount;
+        if (amount >= 0) {
+            this.experience += amount;
+        }
     }
     
     // Internal state modification for progression; should only be called by trusted services like LevelingSystem.
@@ -346,12 +351,13 @@ public class Character implements Serializable {
      * Levels up the character, increasing stats and unlocking ability slots when applicable.
      */
     public void levelUp() {
-        if (!canLevelUp()) return;
-        this.level++;
-        this.battlesWon -= nextLevelMilestone;
-        this.nextLevelMilestone += 5;
-        LevelingSystem.processLevelUp(this);
-        unlockAbilitySlot();
+        if (canLevelUp()) {
+            this.level++;
+            this.battlesWon -= nextLevelMilestone;
+            this.nextLevelMilestone += 5;
+            LevelingSystem.processLevelUp(this);
+            unlockAbilitySlot();
+        }
     }
 
     /** Unlocks an additional ability slot at specific level thresholds. */
@@ -425,13 +431,12 @@ public class Character implements Serializable {
                 && "Elven Cloak".equals(p.getName())
                 && !statusEffectImmunityUsed) {
             statusEffectImmunityUsed = true;
-            return;
+        } else if (activeStatusEffects.size() >= Constants.MAX_STATUS_EFFECTS) {
+            // Too many status effects - optionally throw exception
+        } else {
+            activeStatusEffects.add(effect);
+            effect.applyEffect(this);
         }
-        if (activeStatusEffects.size() >= Constants.MAX_STATUS_EFFECTS) {
-            return; // Or throw exception
-        }
-        activeStatusEffects.add(effect);
-        effect.applyEffect(this);
     }
 
     public void removeStatusEffect(StatusEffectType type) {

--- a/model/item/Inventory.java
+++ b/model/item/Inventory.java
@@ -97,10 +97,9 @@ public final class Inventory implements Serializable {
      */
     public void addItem(MagicItem item) {
         InputValidator.requireNonNull(item, "Item to add");
-        if (items.contains(item)) {
-            return; // prevent duplicates
+        if (!items.contains(item)) {
+            items.add(item);
         }
-        items.add(item);
     }
 
     /**

--- a/model/item/MagicItem.java
+++ b/model/item/MagicItem.java
@@ -97,13 +97,19 @@ public abstract class MagicItem implements Serializable {
      */
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MagicItem that = (MagicItem) o;
-        return name.equals(that.name)
-                && description.equals(that.description)
-                && itemType == that.itemType
-                && rarityType == that.rarityType;
+        boolean result;
+        if (this == o) {
+            result = true;
+        } else if (o == null || getClass() != o.getClass()) {
+            result = false;
+        } else {
+            MagicItem that = (MagicItem) o;
+            result = name.equals(that.name)
+                    && description.equals(that.description)
+                    && itemType == that.itemType
+                    && rarityType == that.rarityType;
+        }
+        return result;
     }
 
     /**

--- a/model/item/SingleUseItem.java
+++ b/model/item/SingleUseItem.java
@@ -77,10 +77,16 @@ public final class SingleUseItem extends MagicItem {
      */
     @Override
     public boolean equals(Object o) {
-        if (!super.equals(o)) return false;
-        if (getClass() != o.getClass()) return false;
-        SingleUseItem that = (SingleUseItem) o;
-        return effectValue == that.effectValue && effectType == that.effectType;
+        boolean result;
+        if (!super.equals(o)) {
+            result = false;
+        } else if (getClass() != o.getClass()) {
+            result = false;
+        } else {
+            SingleUseItem that = (SingleUseItem) o;
+            result = effectValue == that.effectValue && effectType == that.effectType;
+        }
+        return result;
     }
 
     /**

--- a/model/util/DialogUtils.java
+++ b/model/util/DialogUtils.java
@@ -62,16 +62,18 @@ public final class DialogUtils {
      */
     public static boolean showConfirmationDialog(String title, String message) {
         final int[] result = new int[1];
+        boolean ok;
         try {
             SwingUtilities.invokeAndWait(() ->
                 result[0] = JOptionPane.showConfirmDialog(
                     null, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE
                 )
             );
+            ok = true;
         } catch (Exception e) {
             showErrorDialog("Dialog Error", "Unexpected error while displaying confirmation dialog.");
-            return false;
+            ok = false;
         }
-        return result[0] == JOptionPane.YES_OPTION;
+        return ok && result[0] == JOptionPane.YES_OPTION;
     }
 }

--- a/view/InventoryView.java
+++ b/view/InventoryView.java
@@ -320,10 +320,10 @@ public class InventoryView extends JFrame{
 
     /** Shows the detail panel for the provided item. */
     public void displayItemDetails(model.item.MagicItem item, boolean isEquipped) {
-        if (item == null) return;
-        lblName.setText(item.getName());
-        lblType.setText("Type: " + item.getItemType());
-        lblStatus.setText("Status: " + (isEquipped ? "Equipped" : "Not Equipped"));
+        if (item != null) {
+            lblName.setText(item.getName());
+            lblType.setText("Type: " + item.getItemType());
+            lblStatus.setText("Status: " + (isEquipped ? "Equipped" : "Not Equipped"));
         lblRarity.setText("Rarity: " + item.getRarity());
         if (item instanceof model.item.SingleUseItem su) {
             lblEffect.setText("Effect: " + describeEffect(su));
@@ -335,6 +335,7 @@ public class InventoryView extends JFrame{
         cardLayout.show(cardPanel, "DETAIL");
         btnViewItem.setVisible(false);
         btnBack.setVisible(true);
+        }
     }
 
     /** Returns to the inventory list view. */


### PR DESCRIPTION
## Summary
- restructured controller methods to eliminate mid-method `return` statements
- kept method logic under guards or else blocks for single exit points
- updated model classes to avoid early returns and return variables
- improved dialog utilities with result variable
- adjusted inventory view to check item not null

## Testing
- `mvn -q test` *(fails: plugin resolution due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6888549dd0108328be3b786cf452f9b6