### PR TITLE
Fix ability slot unlocks across multi-level ups

### DIFF
--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -352,20 +352,28 @@ public class Character implements Serializable {
      */
     public void levelUp() {
         if (canLevelUp()) {
+            int previousLevel = this.level;
             this.level++;
             this.battlesWon -= nextLevelMilestone;
             this.nextLevelMilestone += 5;
+
             LevelingSystem.processLevelUp(this);
-            unlockAbilitySlot();
+
+            unlockAbilitySlot(previousLevel, this.level);
         }
     }
 
-    /** Unlocks an additional ability slot at specific level thresholds. */
-    public void unlockAbilitySlot() {
-        if (level == 2 || level == 4) {
-            this.abilitySlots++;
-            this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + 1, this.abilitySlots);
-            this.abilitySlotCount = this.unlockedAbilitySlots;
+    /**
+     * Unlocks additional ability slots when crossing levels 2 and 4.
+     * Handles scenarios where multiple levels are gained at once.
+     */
+    private void unlockAbilitySlot(int oldLevel, int newLevel) {
+        for (int lvl = oldLevel + 1; lvl <= newLevel; lvl++) {
+            if (lvl == 2 || lvl == 4) {
+                this.abilitySlots++;
+                this.unlockedAbilitySlots = Math.min(this.unlockedAbilitySlots + 1, this.abilitySlots);
+                this.abilitySlotCount = this.unlockedAbilitySlots;
+            }
         }
     }
 

--- a/src/test/java/model/core/CharacterLevelUpTest.java
+++ b/src/test/java/model/core/CharacterLevelUpTest.java
@@ -1,0 +1,43 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import model.core.Character;
+import model.core.RaceType;
+import model.core.ClassType;
+
+public class CharacterLevelUpTest {
+
+    @Test
+    void levelUpFromOneToThreeUnlocksSlot() throws Exception {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.MAGE);
+        c.addExperience(250); // enough for level 3
+        for (int i = 0; i < 5; i++) {
+            c.incrementBattlesWon();
+        }
+        assertTrue(c.canLevelUp());
+        c.levelUp();
+        assertEquals(3, c.getLevel());
+        assertEquals(4, c.getAbilitySlotCount());
+    }
+
+    @Test
+    void levelUpFromThreeToFiveUnlocksSlot() throws Exception {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.MAGE);
+        c.addExperience(250); // first reach level 3
+        for (int i = 0; i < 5; i++) {
+            c.incrementBattlesWon();
+        }
+        c.levelUp();
+        assertEquals(3, c.getLevel());
+        assertEquals(4, c.getAbilitySlotCount());
+
+        c.addExperience(450); // total 700 -> level 5
+        for (int i = 0; i < 10; i++) {
+            c.incrementBattlesWon();
+        }
+        assertTrue(c.canLevelUp());
+        c.levelUp();
+        assertEquals(5, c.getLevel());
+        assertEquals(5, c.getAbilitySlotCount());
+    }
+}


### PR DESCRIPTION
## Summary
- handle multiple level gains in `Character.levelUp` to unlock ability slots for each threshold crossed
- add unit tests for leveling from 1→3 and 3→5

## Testing
- `javac $(find . -name '*.java')` *(fails: package org.junit.jupiter.api not found)*
- `mvn -q test` *(fails: Could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68888790e2e48328b976b711393ec7dc