### PR TITLE
Refactor loop control flow

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -275,27 +275,27 @@ public final class BattleController {
 
         /* order by priority – higher first (ties resolved arbitrarily) */
         List<Turn> order = buildTurnOrder();
-        for (Turn t : order) {
-            if (!t.actor.isAlive()) continue;
+        for (int i = 0; i < order.size() && !battleEnded(); i++) {
+            Turn t = order.get(i);
+            if (t.actor.isAlive()) {
+                if (t.actor.isStunned()) {
+                    log.addEntry(t.actor.getName() + " is stunned and skips their turn!");
+                } else if (t.target.isAlive()) {
+                    t.move.execute(t.actor, t.target, log);
+                    if (!t.target.isAlive()) {
+                        if (!t.target.checkPhoenixFeather(log)) {
+                            log.addEntry(t.target.getName() + " has fallen!");
+                        }
+                    }
+                    if (!t.actor.isAlive()) {
+                        if (!t.actor.checkPhoenixFeather(log)) {
+                            log.addEntry(t.actor.getName() + " has fallen!");
+                        }
+                    }
+                }
 
-            if (t.actor.isStunned()) {
-                log.addEntry(t.actor.getName() + " is stunned and skips their turn!");
-            } else if (t.target.isAlive()) {
-                t.move.execute(t.actor, t.target, log);
-                if (!t.target.isAlive()) {
-                    if (!t.target.checkPhoenixFeather(log)) {
-                        log.addEntry(t.target.getName() + " has fallen!");
-                    }
-                }
-                if (!t.actor.isAlive()) {
-                    if (!t.actor.checkPhoenixFeather(log)) {
-                        log.addEntry(t.actor.getName() + " has fallen!");
-                    }
-                }
+                t.actor.processEndOfTurnEffects(log);
             }
-
-            t.actor.processEndOfTurnEffects(log);
-            if (battleEnded()) break;
         }
 
         log.addEntry("--- End of Round " + battle.getRoundNumber() + " ---");

--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -202,14 +202,12 @@ public void actionPerformed(ActionEvent e) {
     }
 
     private int getPlayerIndex(String name) {
-        int index = 1;
         for (int i = 0; i < players.size(); i++) {
             if (players.get(i).getName().equalsIgnoreCase(name)) {
-                index = i + 1;
-                break;
+                return i + 1;
             }
         }
-        return index;
+        return 1;
     }
 
     public void handleNavigateToCharacterManagement(Player player) {

--- a/controller/PlayerCharacterManagementController.java
+++ b/controller/PlayerCharacterManagementController.java
@@ -224,12 +224,18 @@ public class PlayerCharacterManagementController {
         if (valid) {
             try {
                 String[] abilityNames = ev.getSelectedAbilities();
-                for (String a : abilityNames) {
+                boolean allSelected = true;
+                int idx = 0;
+                while (idx < abilityNames.length && allSelected) {
+                    String a = abilityNames[idx];
                     if (a == null || a.isBlank()) {
                         ev.showErrorMessage("All ability slots must be selected.");
-                        valid = false;
-                        break;
+                        allSelected = false;
                     }
+                    idx++;
+                }
+                if (!allSelected) {
+                    valid = false;
                 }
 
                 if (valid) {
@@ -243,13 +249,19 @@ public class PlayerCharacterManagementController {
                 if (valid) {
                     java.util.List<String> validList = classService.getAvailableAbilities(c.getClassType())
                             .stream().map(Ability::getName).toList();
-                    for (int i = 0; i < Math.min(3, abilityNames.length); i++) {
+                    boolean selectionValid = true;
+                    int i = 0;
+                    int limit = Math.min(3, abilityNames.length);
+                    while (i < limit && selectionValid) {
                         String a = abilityNames[i];
                         if (!validList.contains(a)) {
                             ev.showErrorMessage("Invalid ability selection for class.");
-                            valid = false;
-                            break;
+                            selectionValid = false;
                         }
+                        i++;
+                    }
+                    if (!selectionValid) {
+                        valid = false;
                     }
                 }
 
@@ -267,11 +279,18 @@ public class PlayerCharacterManagementController {
                     if (itemName == null || itemName.equals("None")) {
                         c.unequipItem();
                     } else {
-                        for (MagicItem mi : c.getInventory().getAllItems()) {
+                        java.util.List<MagicItem> items = c.getInventory().getAllItems();
+                        MagicItem chosen = null;
+                        int j = 0;
+                        while (j < items.size() && chosen == null) {
+                            MagicItem mi = items.get(j);
                             if (mi.getName().equalsIgnoreCase(itemName)) {
-                                c.equipItem(mi);
-                                break;
+                                chosen = mi;
                             }
+                            j++;
+                        }
+                        if (chosen != null) {
+                            c.equipItem(chosen);
                         }
                     }
 

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -311,14 +311,12 @@ public final class SceneManager {
 
     private int playersIndex(Player player) {
         List<Player> list = gameManagerController.getPlayers();
-        int index = 1;
         for (int i = 0; i < list.size(); i++) {
             if (list.get(i) == player) {
-                index = i + 1;
-                break;
+                return i + 1;
             }
         }
-        return index;
+        return 1;
     }
 
     /** Shows the battle mode selection screen. */

--- a/controller/TradeController.java
+++ b/controller/TradeController.java
@@ -272,17 +272,12 @@ public class TradeController implements ActionListener {
     }
 
     private Player findPlayerForCharacter(Character c) throws GameException {
-        Player owner = null;
         for (Player p : players) {
             if (p.getCharacters().contains(c)) {
-                owner = p;
-                break;
+                return p;
             }
         }
-        if (owner == null) {
-            throw new GameException("Character does not belong to any loaded player.");
-        }
-        return owner;
+        throw new GameException("Character does not belong to any loaded player.");
     }
 
     private void persist() throws GameException {

--- a/model/battle/LevelingSystem.java
+++ b/model/battle/LevelingSystem.java
@@ -101,7 +101,7 @@ public final class LevelingSystem {
             if (xp >= e.getValue()) {
                 lvl = e.getKey();
             } else {
-                break; // thresholds are ascending
+                return lvl; // thresholds are ascending
             }
         }
         return lvl;

--- a/model/core/Character.java
+++ b/model/core/Character.java
@@ -231,11 +231,14 @@ public class Character implements Serializable {
             }
 
             if (hasStatusEffect(StatusEffectType.SHIELDED)) {
+                StatusEffect chosen = null;
                 for (StatusEffect se : activeStatusEffects) {
-                    if (se.getType() == StatusEffectType.SHIELDED && se instanceof model.util.effects.ShieldEffect s) {
-                        finalDamage = s.absorb(finalDamage);
-                        break;
+                    if (chosen == null && se.getType() == StatusEffectType.SHIELDED && se instanceof model.util.effects.ShieldEffect) {
+                        chosen = se;
                     }
+                }
+                if (chosen instanceof model.util.effects.ShieldEffect s) {
+                    finalDamage = s.absorb(finalDamage);
                 }
                 removeStatusEffect(StatusEffectType.SHIELDED);
             }

--- a/model/service/ClassService.java
+++ b/model/service/ClassService.java
@@ -147,17 +147,19 @@ public final class ClassService {
         List<Ability> matched = new ArrayList<>();
 
         for (String name : names) {
-            boolean found = false;
-            for (Ability ability : allAbilities) {
+            Ability found = null;
+            int i = 0;
+            while (i < allAbilities.size() && found == null) {
+                Ability ability = allAbilities.get(i);
                 if (ability.getName().equalsIgnoreCase(name)) {
-                    matched.add(ability);
-                    found = true;
-                    break;
+                    found = ability;
                 }
+                i++;
             }
-            if (!found) {
+            if (found == null) {
                 throw new GameException("Ability not found: " + name);
             }
+            matched.add(found);
         }
 
         return matched;

--- a/model/util/SmartBot.java
+++ b/model/util/SmartBot.java
@@ -49,12 +49,13 @@ public final class SmartBot implements AIMoveStrategy {
         List<Move> defensiveMoves = new ArrayList<>();
 
         for (Ability a : bot.getAbilities()) {
-            if (a.getEpCost() > bot.getCurrentEp()) continue;
-            switch (a.getAbilityEffectType()) {
-                case HEAL -> healingMoves.add(new AbilityMove(a));
-                case ENERGY_GAIN -> energyMoves.add(new AbilityMove(a));
-                case DEFENSE, EVADE -> defensiveMoves.add(new AbilityMove(a));
-                default -> attackMoves.add(new AbilityMove(a));
+            if (a.getEpCost() <= bot.getCurrentEp()) {
+                switch (a.getAbilityEffectType()) {
+                    case HEAL -> healingMoves.add(new AbilityMove(a));
+                    case ENERGY_GAIN -> energyMoves.add(new AbilityMove(a));
+                    case DEFENSE, EVADE -> defensiveMoves.add(new AbilityMove(a));
+                    default -> attackMoves.add(new AbilityMove(a));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- remove `continue` and `break` in `BattleController`
- simplify player owner lookup in `TradeController`
- adjust index helpers in `SceneManager` and `GameManagerController`
- replace loop breaking in `PlayerCharacterManagementController`
- refactor shield handling in `Character`
- remove breaks in ability lookup and level logic
- drop continue in `SmartBot`

## Testing
- `mvn -q -DskipTests=false test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688886da2f7c83288e95036c09aa3dd3