### PR TITLE
Fix level up timing after wins

### DIFF
--- a/controller/BattleController.java
+++ b/controller/BattleController.java
@@ -323,14 +323,14 @@ public final class BattleController {
                     log.addEntry(persistentLoser.getName() + " gains 20 XP.");
                     // Delegate win handling (including XP awards and item rewards)
                     // to GameManagerController to avoid double-counting wins.
-
+                    gameManagerController.handlePlayerWin(winPlayer, persistentWinner);
                     if (persistentWinner.canLevelUp()) {
                         persistentWinner.levelUp();
                         javax.swing.JOptionPane.showMessageDialog(null,
-                                persistentWinner.getName() + " reached Level " + persistentWinner.getLevel() + "!",
+                                persistentWinner.getName() + " reached Level " +
+                                        persistentWinner.getLevel() + "!",
                                 "Level Up", javax.swing.JOptionPane.INFORMATION_MESSAGE);
                     }
-                    gameManagerController.handlePlayerWin(winPlayer, persistentWinner);
                 }
             }
 

--- a/tests/CharacterLevelUpTest.java
+++ b/tests/CharacterLevelUpTest.java
@@ -1,0 +1,28 @@
+package tests;
+
+import model.core.Character;
+import model.core.ClassType;
+import model.core.RaceType;
+
+public class CharacterLevelUpTest {
+    public static void main(String[] args) throws Exception {
+        Character c = new Character("Hero", RaceType.HUMAN, ClassType.WARRIOR);
+        // Simulate 4 recorded wins
+        for (int i = 0; i < 4; i++) {
+            c.incrementBattlesWon();
+        }
+
+        assert c.getLevel() == 1 : "Level should start at 1";
+        assert !c.canLevelUp() : "Should not level up before milestone";
+
+        // Record the 5th win and evaluate level up
+        c.incrementBattlesWon();
+        if (c.canLevelUp()) {
+            c.levelUp();
+        }
+
+        assert c.getLevel() == 2 : "Level should increase after fifth win";
+        assert c.getBattlesWon() == 0 : "Battles won should reset after leveling";
+        System.out.println("CharacterLevelUpTest passed");
+    }
+}


### PR DESCRIPTION
## Summary
- adjust win handling order so leveling occurs after incrementing wins
- add a basic test to verify level-up after the fifth win

## Testing
- `cd tests && javac $(find .. -name '*.java')`
- `java tests.CharacterLevelUpTest`

------
https://chatgpt.com/codex/tasks/task_e_688886a67ba483288675b4ae391ca86c