### PR TITLE
Fix MagicItemFactory Javadoc rarity distribution

### DIFF
--- a/model/service/MagicItemFactory.java
+++ b/model/service/MagicItemFactory.java
@@ -14,7 +14,7 @@ import model.item.SingleUseEffectType;
 /**
  * <h2>MagicItemFactory</h2>
  * <p>Static utility class that randomly creates {@link MagicItem} rewards,
- * observing the specified rarity distribution (Common 70%, Uncommon 25%, Rare 5%).</p>
+ * observing the specified rarity distribution (Common 60%, Uncommon 35%, Rare 5%).</p>
  *
  * <p><strong>Design Features:</strong></p>
  * <ul>


### PR DESCRIPTION
## Summary
- correct MagicItemFactory introductory Javadoc so it matches the enum-defined drop chances

## Testing
- `javac $(find . -path ./src/test/java -prune -o -name '*.java' -print)`
- `java tests.CharacterLevelUpTest`
- `mvn -q test` *(fails: Could not resolve plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688895b70ea88328b32dd0bf72a65922