### PR TITLE
Ensure trading item font is white

### DIFF
--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -271,6 +271,7 @@ public class TradeView extends JFrame {
                 setOpaque(false);
                 if (value instanceof model.item.MagicItem mi) {
                     setText((index + 1) + ". " + mi.getName());
+                    setForeground(Color.WHITE);
                 }
                 return this;
             }


### PR DESCRIPTION
## Summary
- set list renderer text color to white in `TradeView`

## Testing
- `mvn test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6889aed2590883289496cc7c78e03bb8