### PR TITLE
Fix trade view list text color

### DIFF
--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -261,6 +261,7 @@ public class TradeView extends JFrame {
         label.setFont(new Font("Serif", Font.BOLD, 17));
 
         list.setFont(new Font("Serif", Font.BOLD, 18));
+        list.setForeground(Color.WHITE); // ensure item text is visible
         list.setOpaque(false);
         list.setVisibleRowCount(6);
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);


### PR DESCRIPTION
## Summary
- ensure item lists in trade view use white text

## Testing
- `mvn -q -DskipTests=false test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6889cc1572ac8328b7126453dffd125f