### PR TITLE
Ensure magic item names display in white

### DIFF
--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -261,7 +261,8 @@ public class TradeView extends JFrame {
         label.setFont(new Font("Serif", Font.BOLD, 17));
 
         list.setFont(new Font("Serif", Font.BOLD, 18));
-        list.setForeground(Color.WHITE); // ensure item text is visible
+        list.setForeground(Color.WHITE);              // default text color
+        list.setSelectionForeground(Color.WHITE);     // keep selected items white
         list.setOpaque(false);
         list.setVisibleRowCount(6);
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -272,8 +273,8 @@ public class TradeView extends JFrame {
                 setOpaque(false);
                 if (value instanceof model.item.MagicItem mi) {
                     setText((index + 1) + ". " + mi.getName());
-                    setForeground(Color.WHITE);
                 }
+                setForeground(Color.WHITE);
                 return this;
             }
         });


### PR DESCRIPTION
## Summary
- keep list item text white in trade view

## Testing
- `mvn test` *(fails: PluginResolutionException)*
- `javac $(find . -name '*.java')` *(fails: missing JUnit)*

------
https://chatgpt.com/codex/tasks/task_e_6889d0d88e188328802a4a5315ebe932