### PR TITLE
Add white text renderer for dropdowns

### DIFF
--- a/view/BattleCharSelectionView.java
+++ b/view/BattleCharSelectionView.java
@@ -270,6 +270,8 @@ public class BattleCharSelectionView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/BattleView.java
+++ b/view/BattleView.java
@@ -32,6 +32,7 @@ import javax.swing.text.StyledDocument;
 import model.battle.CombatLog;
 import model.core.Character;
 import view.OutlinedLabel;
+import view.WhiteTextCellRenderer;
 
 /**
  * The battle view for Fatal Fantasy: Tactics Game.
@@ -422,6 +423,8 @@ public class BattleView extends JFrame {
         label.setFont(new Font("Serif", Font.BOLD, 17));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setAlignmentX(Component.CENTER_ALIGNMENT);
 

--- a/view/CharacterDeleteView.java
+++ b/view/CharacterDeleteView.java
@@ -223,6 +223,8 @@ public class CharacterDeleteView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/CharacterEditView.java
+++ b/view/CharacterEditView.java
@@ -7,6 +7,7 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Image;
+import java.awt.Color;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -21,6 +22,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import view.WhiteTextCellRenderer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -170,6 +172,8 @@ public class CharacterEditView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/CharacterManualCreationView.java
+++ b/view/CharacterManualCreationView.java
@@ -165,6 +165,8 @@ public class CharacterManualCreationView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/CharacterSpecViewingView.java
+++ b/view/CharacterSpecViewingView.java
@@ -237,6 +237,8 @@ private JPanel createDropdownPanel(String labelText, JComboBox<String> dropdown)
     label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
     dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+    dropdown.setForeground(Color.WHITE);
+    dropdown.setRenderer(new WhiteTextCellRenderer());
     dropdown.setMaximumSize(new Dimension(250, 35));
     dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/PlayerDeleteView.java
+++ b/view/PlayerDeleteView.java
@@ -232,6 +232,8 @@ public class PlayerDeleteView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/SavedPlayersRegistrationView.java
+++ b/view/SavedPlayersRegistrationView.java
@@ -143,6 +143,8 @@ public class SavedPlayersRegistrationView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/TradeView.java
+++ b/view/TradeView.java
@@ -30,6 +30,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import view.WhiteTextCellRenderer;
 
 // import controller._;
 
@@ -326,6 +327,8 @@ public class TradeView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/TradingHallView.java
+++ b/view/TradingHallView.java
@@ -7,6 +7,7 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Image;
+import java.awt.Color;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -162,6 +163,8 @@ public class TradingHallView extends JFrame {
         label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
 
         dropdown.setFont(new Font("Serif", Font.BOLD, 18));
+        dropdown.setForeground(Color.WHITE);
+        dropdown.setRenderer(new WhiteTextCellRenderer());
         dropdown.setMaximumSize(new Dimension(250, 35));
         dropdown.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
 

--- a/view/WhiteTextCellRenderer.java
+++ b/view/WhiteTextCellRenderer.java
@@ -1,0 +1,21 @@
+package view;
+
+import java.awt.Color;
+import java.awt.Component;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JList;
+
+/**
+ * Simple cell renderer that renders all items with white foreground text.
+ */
+public class WhiteTextCellRenderer extends DefaultListCellRenderer {
+    @Override
+    public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                  boolean isSelected, boolean cellHasFocus) {
+        super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        setOpaque(false);
+        setForeground(Color.WHITE);
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure dropdown selections render with white text by adding a `WhiteTextCellRenderer`
- apply white foreground and renderer in each `createDropdownPanel` across views

## Testing
- `mvn test` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6889d8a6d9748328bf241f27648807f6