### PR TITLE
Enable cross-class ability option for gnome characters

### DIFF
--- a/controller/CharacterManualCreationController.java
+++ b/controller/CharacterManualCreationController.java
@@ -252,10 +252,14 @@ public final class CharacterManualCreationController {
                     view.setAbilityOptions(i, opts);
                 }
 
-                // If race allows a fourth ability slot (gnome), populate it as well
+                // If race allows a fourth ability slot (gnome), populate with cross-class abilities
                 String raceStr = view.getSelectedRace();
                 if (raceStr != null && !raceStr.isBlank() && RaceType.valueOf(raceStr) == RaceType.GNOME) {
-                    view.setAbilityOptions(4, opts);
+                    List<String> allAbilities = classService.getAllAbilities()
+                            .stream()
+                            .map(Ability::getName)
+                            .collect(Collectors.toList());
+                    view.setAbilityOptions(4, allAbilities.toArray(new String[0]));
                 }
             } catch (GameException e) {
                 // In case of an error fetching abilities, keep the dropdowns empty


### PR DESCRIPTION
## Summary
- allow gnome manual creation to pull the 4th ability from all classes

## Testing
- `mvn -q test` *(fails: maven cannot download dependencies)*
- `javac $(find . -name '*.java')` *(fails: cannot find junit libraries)*

------
https://chatgpt.com/codex/tasks/task_e_688a0b09a40083288739f633cb09aaba