### PR TITLE
Implement derive_all guardrails and derived metrics

### DIFF
--- a/R/derive.R
+++ b/R/derive.R
@@ -1,0 +1,43 @@
+library(dplyr)
+
+derive_all <- function(df) {
+  if (!is.data.frame(df)) {
+    stop("df must be a data.frame")
+  }
+
+  if (!all(c("ApprovedBudgetForContract", "ContractCost", "StartDate", "ActualCompletionDate") %in% names(df))) {
+    stop("df is missing required columns")
+  }
+
+  budget_guard <- !is.na(df$ApprovedBudgetForContract) & abs(df$ApprovedBudgetForContract) > 1e12
+  cost_guard <- !is.na(df$ContractCost) & abs(df$ContractCost) > 1e12
+
+  replaced_budget <- sum(budget_guard)
+  replaced_cost <- sum(cost_guard)
+
+  if (replaced_budget > 0) {
+    df$ApprovedBudgetForContract[budget_guard] <- NA_real_
+  }
+
+  if (replaced_cost > 0) {
+    df$ContractCost[cost_guard] <- NA_real_
+  }
+
+  if (replaced_budget > 0 || replaced_cost > 0) {
+    message(
+      sprintf(
+        "derive_all: replaced %d ApprovedBudgetForContract value(s) and %d ContractCost value(s) exceeding guardrails",
+        replaced_budget,
+        replaced_cost
+      )
+    )
+  }
+
+  df <- df %>%
+    mutate(
+      CostSavings = ApprovedBudgetForContract - ContractCost,
+      CompletionDelayDays = as.numeric(ActualCompletionDate - StartDate)
+    )
+
+  df
+}


### PR DESCRIPTION
## Summary
- add new derive_all helper that computes CostSavings and CompletionDelayDays
- enforce guardrails for extreme budget or cost values and log replacements

## Testing
- Rscript -e "source('R/derive.R'); x<-data.frame(ApprovedBudgetForContract=1,ContractCost=1,StartDate=as.Date('2021-01-01'),ActualCompletionDate=as.Date('2021-01-03')); y<-derive_all(x); stopifnot(all(c('CostSavings','CompletionDelayDays')%in%names(y)), y$CompletionDelayDays==2); cat('DERIVE OK\n')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dde35649d88328a358be15d49fc7f9