### PR TITLE
Fix derive_all guardrails and base derivations

### DIFF
--- a/R/derive.R
+++ b/R/derive.R
@@ -1,0 +1,31 @@
+derive_all <- function(df) {
+  if (!is.data.frame(df)) {
+    stop("df must be a data.frame")
+  }
+
+  required_cols <- c("ApprovedBudgetForContract", "ContractCost", "StartDate", "ActualCompletionDate")
+  if (!all(required_cols %in% names(df))) {
+    stop("df is missing required columns")
+  }
+
+  budget_guard <- !is.na(df$ApprovedBudgetForContract) & abs(df$ApprovedBudgetForContract) > 1e12
+  cost_guard <- !is.na(df$ContractCost) & abs(df$ContractCost) > 1e12
+  replaced_rows <- budget_guard | cost_guard
+
+  if (any(budget_guard)) {
+    df$ApprovedBudgetForContract[budget_guard] <- NA_real_
+  }
+
+  if (any(cost_guard)) {
+    df$ContractCost[cost_guard] <- NA_real_
+  }
+
+  if (any(replaced_rows)) {
+    message(sprintf("derive_all: replaced guardrail values in %d row(s)", sum(replaced_rows)))
+  }
+
+  df$CostSavings <- df$ApprovedBudgetForContract - df$ContractCost
+  df$CompletionDelayDays <- as.numeric(df$ActualCompletionDate - df$StartDate)
+
+  df
+}


### PR DESCRIPTION
## Summary
- implement derive_all using base R so it is always defined when sourced
- log guardrail replacements by affected row count and compute derived columns directly

## Testing
- Rscript -e "source('R/derive.R'); x<-data.frame(ApprovedBudgetForContract=1,ContractCost=1,StartDate=as.Date('2021-01-01'),ActualCompletionDate=as.Date('2021-01-03')); y<-derive_all(x); stopifnot(all(c('CostSavings','CompletionDelayDays')%in%names(y)), y$CompletionDelayDays==2); cat('DERIVE OK\n')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dde35649d88328a358be15d49fc7f9